### PR TITLE
fix: handle null API fields in parse_product

### DIFF
--- a/src/audible_deals/client.py
+++ b/src/audible_deals/client.py
@@ -194,11 +194,11 @@ def parse_product(raw: dict[str, Any], locale: str = "us") -> Product:
     narrators = [n.get("name", "") for n in (raw.get("narrators") or []) if n.get("name")]
 
     # Rating - nested in overall_distribution
-    rating_data = raw.get("rating", {})
+    rating_data = raw.get("rating") or {}
     rating = 0.0
     num_ratings = 0
     if isinstance(rating_data, dict):
-        dist = rating_data.get("overall_distribution", {})
+        dist = rating_data.get("overall_distribution") or {}
         try:
             rating = float(dist.get("display_average_rating", 0) or 0)
         except (ValueError, TypeError):
@@ -211,8 +211,8 @@ def parse_product(raw: dict[str, Any], locale: str = "us") -> Product:
     # Categories - flatten ladder structure
     categories: list[str] = []
     category_ids: list[str] = []
-    for ladder in raw.get("category_ladders", []):
-        for cat in ladder.get("ladder", []):
+    for ladder in (raw.get("category_ladders") or []):
+        for cat in (ladder.get("ladder") or []):
             name = cat.get("name", "")
             cid = cat.get("id", "")
             if name and name not in categories:
@@ -223,7 +223,7 @@ def parse_product(raw: dict[str, Any], locale: str = "us") -> Product:
     # Series info
     series_name = ""
     series_position = ""
-    series_list = raw.get("series", [])
+    series_list = raw.get("series") or []
     if series_list:
         s = series_list[0]
         series_name = s.get("title", "")
@@ -231,7 +231,7 @@ def parse_product(raw: dict[str, Any], locale: str = "us") -> Product:
 
     # Audible Plus detection
     in_plus = False
-    for plan in raw.get("plans", []):
+    for plan in (raw.get("plans") or []):
         pname = plan.get("plan_name", "")
         if "Plus" in pname or "AYCE" in pname:
             in_plus = True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -176,6 +176,20 @@ class TestParseProduct:
         assert p.narrators == []
         assert p.authors == []
 
+    def test_null_plans_and_category_ladders(self):
+        """Library API can return null for plans/category_ladders instead of []."""
+        raw = {
+            "asin": "X", "title": "X",
+            "plans": None, "category_ladders": None,
+            "series": None, "rating": None,
+        }
+        p = parse_product(raw)
+        assert p.in_plus_catalog is False
+        assert p.categories == []
+        assert p.category_ids == []
+        assert p.series_name == ""
+        assert p.rating == 0.0
+
 
 # ===================================================================
 # Category caching (disk)


### PR DESCRIPTION
## Summary
- Audible API can return `null` for list/dict fields (`plans`, `category_ladders`, `series`, `rating`) instead of `[]`/`{}`, causing `TypeError` on iteration
- Replaced all `raw.get("field", default)` calls in `parse_product` with `(raw.get("field") or default)` to handle both missing keys and explicit `None` values
- Added regression test covering all four null fields

Supersedes #8 — thanks to @bradbushSFAI for the original report and diagnosis.

## Test plan
- [x] Empirically verified: old pattern crashes with `TypeError`, new pattern returns correct defaults
- [x] All 50 tests pass, including new `test_null_plans_and_category_ladders`

🤖 Generated with [Claude Code](https://claude.ai/code)