### PR TITLE
refactor: extract Settings, split test monolith, decompose post-process pipeline

### DIFF
--- a/src/audible_deals/cli.py
+++ b/src/audible_deals/cli.py
@@ -71,51 +71,49 @@ from audible_deals.display import (
     display_summary,
     display_watch_table,
 )
-from audible_deals.filtering import (  # noqa: F401 — re-exported for backward compat
-    _dedupe_editions,
-    _filter_products,
-    _first_in_series,
-    _price_per_hour,
-    _sort_local,
-    _value_score,
+from audible_deals.filtering import (
+    dedupe_editions,
+    filter_products,
+    first_in_series as _first_in_series_fn,
+    price_per_hour,
+    sort_local,
+    value_score,
 )
 from audible_deals.settings import Settings
-from audible_deals.constants import _atomic_write  # noqa: F401 — re-exported for backward compat
-from audible_deals.utils import (  # noqa: F401 — re-exported for backward compat
-    _looks_like_person_name,
-    _parse_interval,
-    _validate_asin,
-    _validate_webhook_url,
+from audible_deals.utils import (
+    looks_like_person_name,
+    parse_interval,
+    validate_asin,
+    validate_webhook_url,
 )
-from audible_deals.serialization import (  # noqa: F401 — re-exported for backward compat
-    _PRODUCT_FIELDS,
-    _deserialize_product,
-    _export_products,
-    _serialize_product,
+from audible_deals.serialization import (
+    deserialize_product,
+    export_products,
+    serialize_product,
 )
-from audible_deals.state import (  # noqa: F401 — re-exported for backward compat
-    _clear_last_results,
-    _clear_seen_asins,
-    _coerce_config_value,
-    _find_wishlist_hits,
-    _has_price_history,
-    _load_config,
-    _load_last_results,
-    _load_price_history,
-    _load_profiles,
-    _load_seen_asins,
-    _load_wishlist,
-    _merge_seen_asins,
-    _record_prices,
-    _resolve_last_references,
-    _save_config,
-    _save_last_results,
-    _save_profiles,
-    _save_seen_asins,
-    _save_wishlist,
-    _scan_price_changes,
-    _validate_config_key,
-    _wishlist_entry,
+from audible_deals.state import (
+    clear_last_results,
+    clear_seen_asins,
+    coerce_config_value,
+    find_wishlist_hits,
+    has_price_history,
+    load_config,
+    load_last_results,
+    load_price_history,
+    load_profiles,
+    load_seen_asins,
+    load_wishlist,
+    merge_seen_asins,
+    record_prices,
+    resolve_last_references,
+    save_config,
+    save_last_results,
+    save_profiles,
+    save_seen_asins,
+    save_wishlist,
+    scan_price_changes,
+    validate_config_key,
+    wishlist_entry,
 )
 
 
@@ -130,7 +128,7 @@ def _get_client(locale: str) -> DealsClient:
 def _safe_record_prices(products: list[Product]) -> None:
     """Record prices, warning on failure instead of crashing."""
     try:
-        _record_prices(products)
+        record_prices(products)
     except Exception as e:
         console.print(f"[dim]Warning: could not record price history: {e}[/dim]")
 
@@ -146,7 +144,7 @@ def _resolve_scan_settings(
     """Merge config/profile/CLI and return an updated namespace dict."""
     profile: dict | None = None
     if profile_name:
-        profiles = _load_profiles()
+        profiles = load_profiles()
         if profile_name not in profiles:
             raise click.ClickException(
                 f"Profile '{profile_name}' not found. "
@@ -235,7 +233,7 @@ def _postprocess_and_output(
     publisher: str = "",
 ) -> None:
     """Shared post-processing pipeline for search and find commands."""
-    filtered, filter_breakdown = _filter_products(
+    filtered, filter_breakdown = filter_products(
         all_products,
         max_price=max_price,
         min_rating=min_rating,
@@ -254,16 +252,16 @@ def _postprocess_and_output(
         series=series,
         publisher=publisher,
     )
-    filtered, editions_removed = _dedupe_editions(filtered)
+    filtered, editions_removed = dedupe_editions(filtered)
     series_collapsed = 0
     if first_in_series:
-        filtered, series_collapsed = _first_in_series(filtered)
-    filtered = _sort_local(filtered, sort)
+        filtered, series_collapsed = _first_in_series_fn(filtered)
+    filtered = sort_local(filtered, sort)
     _safe_record_prices(filtered)
-    serialized_all = [_serialize_product(p) for p in filtered]
+    serialized_all = [serialize_product(p) for p in filtered]
     if write_cache:
         try:
-            _save_last_results(title, serialized_all)
+            save_last_results(title, serialized_all)
         except Exception:
             pass
     total_before_limit = len(filtered)
@@ -273,10 +271,10 @@ def _postprocess_and_output(
     else:
         serialized = serialized_all
     if write_cache:
-        _save_seen_asins({p.asin for p in filtered})
+        save_seen_asins({p.asin for p in filtered})
 
     if output:
-        _export_products(filtered, output)
+        export_products(filtered, output)
         console.print(f"[green]Exported {len(filtered)} items to {output}[/green]")
     if json_flag:
         click.echo(json_mod.dumps(serialized, indent=2, ensure_ascii=False))
@@ -327,7 +325,7 @@ def _interactive_browse(products: list[Product]) -> None:
             console.print(f"[dim]Opening {p.url}[/dim]")
             click.launch(p.url)
         elif action == "wishlist":
-            items = _load_wishlist()
+            items = load_wishlist()
             if any(item["asin"] == p.asin for item in items):
                 console.print(f"[dim]{p.asin} already on wishlist[/dim]")
             else:
@@ -338,8 +336,8 @@ def _interactive_browse(products: list[Product]) -> None:
                         target_price = float(raw)
                 except (ValueError, EOFError):
                     pass
-                items.append(_wishlist_entry(p, target_price))
-                _save_wishlist(items)
+                items.append(wishlist_entry(p, target_price))
+                save_wishlist(items)
                 target_note = f" (target: {p.currency}{target_price:.2f})" if target_price is not None else ""
                 console.print(f"[green]+[/green] {p.title} added to wishlist{target_note}")
 
@@ -363,7 +361,7 @@ class _HandleAuthErrors(click.Group):
 def cli(ctx, locale):
     """Audible deal finder - find cheap audiobooks during sales."""
     ctx.ensure_object(dict)
-    cfg = _load_config()
+    cfg = load_config()
     ctx.obj["config"] = cfg
     if ctx.get_parameter_source("locale") != _CL:
         cfg_locale = cfg.get("locale")
@@ -544,7 +542,7 @@ def search(ctx, query, max_price, max_pph, category, genre, exclude_genre, sort,
 
         if skip_owned:
             skip_asins = dc.get_library_asins()
-        skip_asins = _merge_seen_asins(skip_asins, exclude_seen)
+        skip_asins = merge_seen_asins(skip_asins, exclude_seen)
 
         queries = [q.strip() for q in query.split("|") if q.strip()] if "|" in query else [query]
         if not queries:
@@ -614,7 +612,7 @@ def search(ctx, query, max_price, max_pph, category, genre, exclude_genre, sort,
         min_discount=min_discount, series=series, publisher=publisher,
     )
     display_query = queries[0] if len(queries) == 1 else None
-    if display_query and not author and not json_flag and not quiet and _looks_like_person_name(display_query):
+    if display_query and not author and not json_flag and not quiet and looks_like_person_name(display_query):
         console.print(f"\n  [dim]Tip: Use --author '{display_query}' for exact author filtering.[/dim]")
 
 
@@ -754,7 +752,7 @@ def find(ctx, category, genre, exclude_genre, keywords, max_price, max_pph, sort
 
         if skip_owned:
             skip_asins = dc.get_library_asins()
-        skip_asins = _merge_seen_asins(skip_asins, exclude_seen)
+        skip_asins = merge_seen_asins(skip_asins, exclude_seen)
 
         desc_parts = []
         if keywords:
@@ -840,7 +838,7 @@ def library(ctx, sort, limit, output, json_flag, quiet, author, narrator, genre,
                 progress.update(task, completed=page_num, items=len(all_products))
             progress.update(task, total=page_count, completed=page_count)
 
-    filtered, filter_breakdown = _filter_products(
+    filtered, filter_breakdown = filter_products(
         all_products,
         author=author,
         narrator=narrator,
@@ -850,7 +848,7 @@ def library(ctx, sort, limit, output, json_flag, quiet, author, narrator, genre,
         genre=genre,
     )
 
-    filtered = _sort_local(filtered, sort)
+    filtered = sort_local(filtered, sort)
     total_before_limit = len(filtered)
     if limit is not None and limit > 0:
         filtered = filtered[:limit]
@@ -858,10 +856,10 @@ def library(ctx, sort, limit, output, json_flag, quiet, author, narrator, genre,
     cur = LOCALE_CURRENCY.get(ctx.obj["locale"], "$")
 
     if output:
-        _export_products(filtered, output)
+        export_products(filtered, output)
         console.print(f"[green]Exported {len(filtered)} items to {output}[/green]")
     if json_flag:
-        serialized = [_serialize_product(p) for p in filtered]
+        serialized = [serialize_product(p) for p in filtered]
         click.echo(json_mod.dumps(serialized, indent=2, ensure_ascii=False))
     if not json_flag and not quiet:
         console.print()
@@ -1084,13 +1082,13 @@ def last_cmd(ctx, sort, max_price, max_pph, min_rating, min_ratings, min_hours, 
     """
     did_clear = False
     if clear_seen:
-        if _clear_seen_asins():
+        if clear_seen_asins():
             console.print("[green]Seen ASINs list cleared.[/green]")
         else:
             console.print("[dim]No seen ASINs to clear.[/dim]")
         did_clear = True
     if clear:
-        if _clear_last_results():
+        if clear_last_results():
             console.print("[green]Last results cache cleared.[/green]")
         else:
             console.print("[dim]No cached results to clear.[/dim]")
@@ -1098,13 +1096,13 @@ def last_cmd(ctx, sort, max_price, max_pph, min_rating, min_ratings, min_hours, 
     if did_clear:
         return
     if count_only:
-        cached_title, data = _load_last_results()
+        cached_title, data = load_last_results()
         click.echo(len(data))
         return
     if output and ctx.get_parameter_source("quiet") != _CL:
         quiet = True
-    cached_title, data = _load_last_results()
-    products = [p for d in data if (p := _deserialize_product(d)) is not None]
+    cached_title, data = load_last_results()
+    products = [p for d in data if (p := deserialize_product(d)) is not None]
     if json_flag:
         console.file = sys.stderr
 
@@ -1133,12 +1131,12 @@ def last_cmd(ctx, sort, max_price, max_pph, min_rating, min_ratings, min_hours, 
 def detail(ctx, asin, last_ref):
     """Show detailed info for a product by ASIN."""
     if last_ref is not None:
-        resolved = _resolve_last_references((last_ref,))
+        resolved = resolve_last_references((last_ref,))
         asin, desc = resolved[0]
         console.print(f"[dim]{desc}[/dim]")
     if not asin:
         raise click.UsageError("Provide an ASIN or use --last N.")
-    _validate_asin(asin)
+    validate_asin(asin)
     dc = _get_client(ctx.obj["locale"])
     with dc:
         try:
@@ -1156,12 +1154,12 @@ def detail(ctx, asin, last_ref):
 def open_cmd(ctx, asin, last_ref):
     """Open an audiobook's Audible page in your browser."""
     if last_ref is not None:
-        resolved = _resolve_last_references((last_ref,))
+        resolved = resolve_last_references((last_ref,))
         asin, desc = resolved[0]
         console.print(f"[dim]{desc}[/dim]")
     if not asin:
         raise click.UsageError("Provide an ASIN or use --last N.")
-    _validate_asin(asin)
+    validate_asin(asin)
     domain = LOCALE_DOMAIN.get(ctx.obj["locale"], "www.audible.com")
     url = f"https://{domain}/pd/{asin}"
     console.print(f"[dim]Opening {url}[/dim]")
@@ -1182,7 +1180,7 @@ def compare(ctx, asins, last_refs):
     """
     all_asins = list(asins)
     if last_refs:
-        resolved = _resolve_last_references(last_refs)
+        resolved = resolve_last_references(last_refs)
         for ref_asin, desc in resolved:
             console.print(f"[dim]{desc}[/dim]")
             all_asins.append(ref_asin)
@@ -1191,7 +1189,7 @@ def compare(ctx, asins, last_refs):
         raise click.UsageError("Provide at least 2 ASINs to compare.")
 
     for asin in all_asins:
-        _validate_asin(asin)
+        validate_asin(asin)
 
     dc = _get_client(ctx.obj["locale"])
     with dc:
@@ -1232,18 +1230,18 @@ def wishlist_add(ctx, asins, max_price, last_refs):
     """
     all_asins = list(asins)
     if last_refs:
-        resolved = _resolve_last_references(last_refs)
+        resolved = resolve_last_references(last_refs)
         for ref_asin, desc in resolved:
             console.print(f"[dim]{desc}[/dim]")
             all_asins.append(ref_asin)
     if not all_asins:
         raise click.UsageError("Provide at least one ASIN or use --last N.")
 
-    items = _load_wishlist()
+    items = load_wishlist()
     existing = {item["asin"] for item in items}
 
     for asin in all_asins:
-        _validate_asin(asin)
+        validate_asin(asin)
 
     dc = _get_client(ctx.obj["locale"])
     added = 0
@@ -1257,12 +1255,12 @@ def wishlist_add(ctx, asins, max_price, last_refs):
             except ValueError:
                 console.print(f"[red]Not found: {asin}[/red]")
                 continue
-            items.append(_wishlist_entry(p, max_price))
+            items.append(wishlist_entry(p, max_price))
             existing.add(p.asin)
             added += 1
             console.print(f"[green]+[/green] {p.title} ({p.asin})")
 
-    _save_wishlist(items)
+    save_wishlist(items)
     console.print(f"\n[bold]{added}[/bold] added, {len(items)} total on wishlist")
 
 
@@ -1273,19 +1271,19 @@ def wishlist_remove(asins, last_refs):
     """Remove ASINs from your wishlist."""
     all_asins = list(asins)
     if last_refs:
-        resolved = _resolve_last_references(last_refs)
+        resolved = resolve_last_references(last_refs)
         for ref_asin, desc in resolved:
             console.print(f"[dim]{desc}[/dim]")
             all_asins.append(ref_asin)
     if not all_asins:
         raise click.UsageError("Provide at least one ASIN or use --last N.")
     for asin in all_asins:
-        _validate_asin(asin)
-    items = _load_wishlist()
+        validate_asin(asin)
+    items = load_wishlist()
     remove_set = set(all_asins)
     before = len(items)
     items = [i for i in items if i["asin"] not in remove_set]
-    _save_wishlist(items)
+    save_wishlist(items)
     removed = before - len(items)
     console.print(f"[bold]{removed}[/bold] removed, {len(items)} remaining")
 
@@ -1295,7 +1293,7 @@ def wishlist_remove(asins, last_refs):
 def wishlist_list(ctx):
     """Show your wishlist."""
     cur = LOCALE_CURRENCY.get(ctx.obj["locale"], "$")
-    items = _load_wishlist()
+    items = load_wishlist()
     if not items:
         console.print("[dim]Wishlist is empty. Use 'deals wishlist add ASIN' to add items.[/dim]")
         return
@@ -1335,7 +1333,7 @@ def wishlist_sync(ctx, max_price, update):
     with dc:
         audible_items = dc.get_wishlist()
 
-    local_items = _load_wishlist()
+    local_items = load_wishlist()
     local_by_asin = {item["asin"]: item for item in local_items}
     cur = LOCALE_CURRENCY.get(ctx.obj["locale"], "$")
 
@@ -1351,11 +1349,11 @@ def wishlist_sync(ctx, max_price, update):
             else:
                 skipped += 1
             continue
-        local_items.append(_wishlist_entry(product, max_price))
+        local_items.append(wishlist_entry(product, max_price))
         added += 1
         console.print(f"[green]+[/green] {product.title} ({product.asin})")
 
-    _save_wishlist(local_items)
+    save_wishlist(local_items)
     console.print(
         f"\n[bold]{added}[/bold] synced, "
         f"{updated} updated, "
@@ -1368,7 +1366,7 @@ def wishlist_sync(ctx, max_price, update):
 
 def _watch_once(ctx: click.Context, buy_only: bool = False, sort_by: str | None = None, show_url: bool = False) -> int:
     """Run a single wishlist price check. Returns the number of BUY hits."""
-    items = _load_wishlist()
+    items = load_wishlist()
     if not items:
         console.print("[dim]Wishlist is empty. Use 'deals wishlist add ASIN' to add items.[/dim]")
         return 0
@@ -1389,7 +1387,7 @@ def _watch_once(ctx: click.Context, buy_only: bool = False, sort_by: str | None 
         return 0
 
     if sort_by:
-        products = _sort_local(products, sort_by)
+        products = sort_local(products, sort_by)
 
     cur = LOCALE_CURRENCY.get(ctx.obj["locale"], "$")
     return display_watch_table(products, targets, cur, buy_only, show_url)
@@ -1423,7 +1421,7 @@ def watch(ctx, every, buy_only, sort_by, show_url):
         _watch_once(ctx, buy_only=buy_only, sort_by=sort_by, show_url=show_url)
         return
 
-    interval = _parse_interval(every)
+    interval = parse_interval(every)
     console.print(f"[dim]Watching every {every} (Ctrl+C to stop)...[/dim]\n")
     try:
         while True:
@@ -1453,11 +1451,11 @@ def config_set(key, value):
         deals config set max-price 5
         deals config set skip-owned true
     """
-    norm_key = _validate_config_key(key)
-    coerced = _coerce_config_value(norm_key, value)
-    cfg = _load_config()
+    norm_key = validate_config_key(key)
+    coerced = coerce_config_value(norm_key, value)
+    cfg = load_config()
     cfg[norm_key] = coerced
-    _save_config(cfg)
+    save_config(cfg)
     console.print(f"[green]Config set:[/green] {norm_key} = {coerced!r}")
 
 
@@ -1465,8 +1463,8 @@ def config_set(key, value):
 @click.argument("key")
 def config_get(key):
     """Get a global default value."""
-    norm_key = _validate_config_key(key)
-    cfg = _load_config()
+    norm_key = validate_config_key(key)
+    cfg = load_config()
     if norm_key not in cfg:
         console.print(f"[dim]{norm_key} is not set[/dim]")
     else:
@@ -1476,7 +1474,7 @@ def config_get(key):
 @config_cmd.command("list")
 def config_list():
     """List all set global defaults."""
-    cfg = _load_config()
+    cfg = load_config()
     if not cfg:
         console.print("[dim]No global defaults set. Use 'deals config set KEY VALUE' to set one.[/dim]")
         return
@@ -1488,18 +1486,18 @@ def config_list():
 @click.argument("key", required=False, default=None)
 def config_reset(key):
     """Remove a key from global defaults, or clear all if no key given."""
-    cfg = _load_config()
+    cfg = load_config()
     if key is None:
         if not click.confirm("Remove all global defaults?"):
             console.print("[dim]Cancelled.[/dim]")
             return
-        _save_config({})
+        save_config({})
         console.print("[green]All global defaults cleared.[/green]")
         return
-    norm_key = _validate_config_key(key)
+    norm_key = validate_config_key(key)
     if norm_key in cfg:
         del cfg[norm_key]
-        _save_config(cfg)
+        save_config(cfg)
         console.print(f"[green]Config key '{norm_key}' removed.[/green]")
     else:
         console.print(f"[dim]Config key '{norm_key}' was not set.[/dim]")
@@ -1548,18 +1546,18 @@ def profile_save(ctx, name, **kwargs):
         deals find --profile my-scifi
         deals search "Brandon Sanderson" --profile my-scifi
     """
-    profiles = _load_profiles()
+    profiles = load_profiles()
     # Only save values explicitly passed on the command line
     saved = {k: v for k, v in kwargs.items() if ctx.get_parameter_source(k) == _CL}
     profiles[name] = saved
-    _save_profiles(profiles)
+    save_profiles(profiles)
     console.print(f"[green]Profile '{name}' saved[/green] ({len(saved)} options)")
 
 
 @profile.command("list")
 def profile_list():
     """List saved profiles."""
-    profiles = _load_profiles()
+    profiles = load_profiles()
     if not profiles:
         console.print("[dim]No profiles saved. Use 'deals profile save NAME --flags...' to create one.[/dim]")
         return
@@ -1573,11 +1571,11 @@ def profile_list():
 @click.argument("name")
 def profile_delete(name):
     """Delete a saved profile."""
-    profiles = _load_profiles()
+    profiles = load_profiles()
     if name not in profiles:
         raise click.ClickException(f"Profile '{name}' not found.")
     del profiles[name]
-    _save_profiles(profiles)
+    save_profiles(profiles)
     console.print(f"[green]Profile '{name}' deleted[/green]")
 
 
@@ -1606,7 +1604,7 @@ def _opts_to_flag_parts(opts: dict) -> list[str]:
 @click.argument("name")
 def profile_show(name):
     """Show the saved flags for a named profile."""
-    profiles = _load_profiles()
+    profiles = load_profiles()
     if name not in profiles:
         raise click.ClickException(f"Profile '{name}' not found.")
     opts = profiles[name]
@@ -1627,13 +1625,13 @@ def history(ctx, asin, last_ref):
     search/find results. Use 'deals history ASIN' to view past prices.
     """
     if last_ref is not None:
-        resolved = _resolve_last_references((last_ref,))
+        resolved = resolve_last_references((last_ref,))
         asin, desc = resolved[0]
         console.print(f"[dim]{desc}[/dim]")
     if not asin:
         raise click.UsageError("Provide an ASIN or use --last N.")
-    _validate_asin(asin)
-    entries = _load_price_history(asin)
+    validate_asin(asin)
+    entries = load_price_history(asin)
     if not entries:
         console.print(
             f"[dim]No price history for {asin}. "
@@ -1656,11 +1654,11 @@ def recap(ctx, days, show_new):
     new items tracked, and wishlist items at target.
     """
     cur = LOCALE_CURRENCY.get(ctx.obj["locale"], "$")
-    drops, new_items = _scan_price_changes(days)
-    if not drops and not new_items and not _has_price_history():
+    drops, new_items = scan_price_changes(days)
+    if not drops and not new_items and not has_price_history():
         console.print("[dim]No price history yet. Run 'deals find' or 'deals search' to start tracking.[/dim]")
         return
-    wishlist_hits = _find_wishlist_hits()
+    wishlist_hits = find_wishlist_hits()
     display_recap(drops, new_items, wishlist_hits, days, cur, show_new)
 
 
@@ -1676,9 +1674,9 @@ def notify(ctx, webhook):
         deals notify  (prints to stdout as JSON, useful for cron + mail)
     """
     if webhook:
-        _validate_webhook_url(webhook)
+        validate_webhook_url(webhook)
 
-    items = _load_wishlist()
+    items = load_wishlist()
     if not items:
         console.print("[dim]Wishlist is empty. Use 'deals wishlist add' first.[/dim]")
         return

--- a/src/audible_deals/cli.py
+++ b/src/audible_deals/cli.py
@@ -20,6 +20,7 @@ Usage:
 
 from __future__ import annotations
 
+import dataclasses
 import json as json_mod
 import math
 import os
@@ -47,6 +48,7 @@ from audible_deals.constants import (
     CLIENT_SORT_OPTIONS,
     CONFIG_FILE,
     DEEP_SORT_ORDERS,
+    DEFAULT_LIMIT,
     HISTORY_DIR,
     LAST_RESULTS_FILE,
     LOCALE_CURRENCY,
@@ -74,7 +76,7 @@ from audible_deals.display import (
 from audible_deals.filtering import (
     dedupe_editions,
     filter_products,
-    first_in_series as _first_in_series_fn,
+    first_in_series,
     price_per_hour,
     sort_local,
     value_score,
@@ -136,38 +138,16 @@ def _safe_record_prices(products: list[Product]) -> None:
 _CL = click.core.ParameterSource.COMMANDLINE
 
 
-def _resolve_scan_settings(
-    ctx: click.Context,
-    profile_name: str | None,
-    cli_flags: dict,
-) -> dict:
-    """Merge config/profile/CLI and return an updated namespace dict."""
-    profile: dict | None = None
-    if profile_name:
-        profiles = load_profiles()
-        if profile_name not in profiles:
-            raise click.ClickException(
-                f"Profile '{profile_name}' not found. "
-                "Use 'deals profile list' to see available profiles."
-            )
-        profile = profiles[profile_name]
-    s = Settings.resolve(
-        ctx,
-        config=ctx.obj.get("config", {}),
-        profile=profile,
-        cli_flags=cli_flags,
-    )
-    # Write resolved settings back into the namespace dict
-    result = dict(cli_flags)
-    for key in (
-        "max_price", "sort", "pages", "min_rating", "min_ratings", "min_hours",
-        "min_discount", "max_pph", "limit", "language", "narrator", "author",
-        "series", "publisher", "on_sale", "deep", "first_in_series", "all_languages",
-        "skip_owned", "interactive", "genre", "exclude_genre", "exclude_authors",
-        "exclude_narrators", "keywords",
-    ):
-        result[key] = getattr(s, key)
-    return result
+def _load_profile(profile_name: str | None) -> dict | None:
+    if not profile_name:
+        return None
+    profiles = load_profiles()
+    if profile_name not in profiles:
+        raise click.ClickException(
+            f"Profile '{profile_name}' not found. "
+            "Use 'deals profile list' to see available profiles."
+        )
+    return profiles[profile_name]
 
 
 def _resolve_categories(
@@ -216,7 +196,7 @@ def _apply_filters(
     on_sale: bool,
     skip_asins: set[str] | None,
     exclude_category_ids: set[str],
-    do_first_in_series: bool,
+    first_in_series_only: bool,
     sort: str,
     max_pph: float | None = None,
     min_discount: int = 0,
@@ -245,8 +225,8 @@ def _apply_filters(
     )
     filtered, editions_removed = dedupe_editions(filtered)
     series_collapsed = 0
-    if do_first_in_series:
-        filtered, series_collapsed = _first_in_series_fn(filtered)
+    if first_in_series_only:
+        filtered, series_collapsed = first_in_series(filtered)
     filtered = sort_local(filtered, sort)
     return filtered, filter_breakdown, editions_removed, series_collapsed
 
@@ -476,7 +456,7 @@ def _common_filter_options(func):
         click.option("--first-in-series/--no-first-in-series", default=False, help="Show only the first book per series"),
         click.option("--skip-owned/--no-skip-owned", default=False, help="Exclude books already in your library"),
         click.option("--exclude-seen", is_flag=True, default=False, help="Exclude ASINs from last search/find results"),
-        click.option("--limit", "-n", type=click.IntRange(min=0), default=25, help="Show only the top N results (0 for unlimited, default: 25)"),
+        click.option("--limit", "-n", type=click.IntRange(min=0), default=DEFAULT_LIMIT, help="Show only the top N results (0 for unlimited, default: 25)"),
         click.option("--output", "-o", type=click.Path(path_type=Path), default=None, help="Export results to file (.json or .csv)"),
         click.option("--json", "json_flag", is_flag=True, default=False, help="Output results as JSON to stdout"),
         click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress table output (useful with --output)"),
@@ -496,7 +476,14 @@ def _build_scan_namespace(
     **kwargs,
 ) -> dict:
     """Build a resolved namespace dict from command kwargs + config/profile defaults."""
-    ns = _resolve_scan_settings(ctx, profile_name, dict(kwargs))
+    s = Settings.resolve(
+        ctx,
+        config=ctx.obj.get("config", {}),
+        profile=_load_profile(profile_name),
+        cli_flags=dict(kwargs),
+    )
+    ns = dict(kwargs)
+    ns.update(dataclasses.asdict(s))
     if ns.get("output") and ctx.get_parameter_source("quiet") != _CL:
         ns["quiet"] = True
     if ns.get("json_flag"):
@@ -626,7 +613,7 @@ def search(ctx, query, max_price, max_pph, category, genre, exclude_genre, sort,
         exclude_narrators=exclude_narrators,
         language=language, on_sale=on_sale, skip_asins=skip_asins,
         exclude_category_ids=exclude_category_ids,
-        do_first_in_series=first_in_series, sort=sort, max_pph=max_pph,
+        first_in_series_only=first_in_series, sort=sort, max_pph=max_pph,
         min_discount=min_discount, series=series, publisher=publisher,
     )
     filtered, serialized, total_before_limit = _record_and_cache(
@@ -815,7 +802,7 @@ def find(ctx, category, genre, exclude_genre, keywords, max_price, max_pph, sort
         exclude_narrators=exclude_narrators,
         language=language, on_sale=on_sale, skip_asins=skip_asins,
         exclude_category_ids=exclude_category_ids,
-        do_first_in_series=first_in_series, sort=sort, max_pph=max_pph,
+        first_in_series_only=first_in_series, sort=sort, max_pph=max_pph,
         min_discount=min_discount, series=series, publisher=publisher,
     )
     filtered, serialized, total_before_limit = _record_and_cache(
@@ -950,13 +937,18 @@ def series(ctx, min_books, max_series, series_filter, max_price, min_rating, min
     if json_flag:
         console.file = sys.stderr
 
-    ns = _resolve_scan_settings(ctx, None, dict(
-        max_price=max_price, min_rating=min_rating, min_ratings=min_ratings,
-        min_hours=min_hours, on_sale=on_sale, limit=limit, sort=sort, pages=pages,
-    ))
-    max_price, min_rating, min_ratings = ns["max_price"], ns["min_rating"], ns["min_ratings"]
-    min_hours, on_sale, limit = ns["min_hours"], ns["on_sale"], ns["limit"]
-    sort, pages = ns["sort"], ns["pages"]
+    s = Settings.resolve(
+        ctx,
+        config=ctx.obj.get("config", {}),
+        profile=None,
+        cli_flags=dict(
+            max_price=max_price, min_rating=min_rating, min_ratings=min_ratings,
+            min_hours=min_hours, on_sale=on_sale, limit=limit, sort=sort, pages=pages,
+        ),
+    )
+    max_price, min_rating, min_ratings = s.max_price, s.min_rating, s.min_ratings
+    min_hours, on_sale, limit = s.min_hours, s.on_sale, s.limit
+    sort, pages = s.sort, s.pages
 
     dc = _get_client(ctx.obj["locale"])
     cur = LOCALE_CURRENCY.get(ctx.obj["locale"], "$")
@@ -1058,7 +1050,7 @@ def series(ctx, min_books, max_series, series_filter, max_price, min_rating, min
         min_hours=min_hours, narrator="", author="",
         exclude_authors=(), exclude_narrators=(), language="",
         on_sale=on_sale, skip_asins=None, exclude_category_ids=set(),
-        do_first_in_series=False, sort=sort,
+        first_in_series_only=False, sort=sort,
     )
     filtered, serialized, total_before_limit = _record_and_cache(
         filtered, title=series_title, limit=limit,
@@ -1151,7 +1143,7 @@ def last_cmd(ctx, sort, max_price, max_pph, min_rating, min_ratings, min_hours, 
         exclude_narrators=exclude_narrators,
         language=language, on_sale=on_sale, skip_asins=None,
         exclude_category_ids=set(),
-        do_first_in_series=first_in_series, sort=effective_sort, max_pph=max_pph,
+        first_in_series_only=first_in_series, sort=effective_sort, max_pph=max_pph,
         min_discount=min_discount, series=series, publisher=publisher,
     )
     filtered, serialized, total_before_limit = _record_and_cache(

--- a/src/audible_deals/cli.py
+++ b/src/audible_deals/cli.py
@@ -201,10 +201,9 @@ def _resolve_categories(
     return category, category_name, exclude_category_ids
 
 
-def _postprocess_and_output(
+def _apply_filters(
     all_products: list[Product],
     *,
-    title: str,
     max_price: float | None,
     min_rating: float,
     min_ratings: int = 0,
@@ -217,22 +216,14 @@ def _postprocess_and_output(
     on_sale: bool,
     skip_asins: set[str] | None,
     exclude_category_ids: set[str],
-    first_in_series: bool,
+    do_first_in_series: bool,
     sort: str,
-    limit: int | None,
-    output: Path | None,
-    json_flag: bool,
-    quiet: bool,
-    currency: str = "$",
-    interactive: bool = False,
-    write_cache: bool = True,
-    show_url: bool = False,
     max_pph: float | None = None,
     min_discount: int = 0,
     series: str = "",
     publisher: str = "",
-) -> None:
-    """Shared post-processing pipeline for search and find commands."""
+) -> tuple[list[Product], dict[str, int], int, int]:
+    """Filter, deduplicate, and sort products. Returns (filtered, breakdown, editions_removed, series_collapsed)."""
     filtered, filter_breakdown = filter_products(
         all_products,
         max_price=max_price,
@@ -254,9 +245,20 @@ def _postprocess_and_output(
     )
     filtered, editions_removed = dedupe_editions(filtered)
     series_collapsed = 0
-    if first_in_series:
+    if do_first_in_series:
         filtered, series_collapsed = _first_in_series_fn(filtered)
     filtered = sort_local(filtered, sort)
+    return filtered, filter_breakdown, editions_removed, series_collapsed
+
+
+def _record_and_cache(
+    filtered: list[Product],
+    *,
+    title: str,
+    write_cache: bool = True,
+    limit: int | None,
+) -> tuple[list[Product], list[dict], int]:
+    """Record prices, persist cache, apply limit. Returns (filtered_limited, serialized, total_before_limit)."""
     _safe_record_prices(filtered)
     serialized_all = [serialize_product(p) for p in filtered]
     if write_cache:
@@ -272,7 +274,27 @@ def _postprocess_and_output(
         serialized = serialized_all
     if write_cache:
         save_seen_asins({p.asin for p in filtered})
+    return filtered, serialized, total_before_limit
 
+
+def _emit_output(
+    filtered: list[Product],
+    serialized: list[dict],
+    *,
+    title: str,
+    output: Path | None,
+    json_flag: bool,
+    quiet: bool,
+    max_price: float | None,
+    filter_breakdown: dict[str, int],
+    editions_removed: int,
+    series_collapsed: int,
+    total_before_limit: int,
+    currency: str = "$",
+    interactive: bool = False,
+    show_url: bool = False,
+) -> None:
+    """Write results to file, JSON stdout, or the terminal table."""
     if output:
         export_products(filtered, output)
         console.print(f"[green]Exported {len(filtered)} items to {output}[/green]")
@@ -284,7 +306,6 @@ def _postprocess_and_output(
         display_summary(len(filtered), filter_breakdown, max_price=max_price,
                         editions_removed=editions_removed, series_collapsed=series_collapsed,
                         currency=currency, total_before_limit=total_before_limit)
-
     if interactive and filtered and not json_flag:
         _interactive_browse(filtered)
 
@@ -598,18 +619,27 @@ def search(ctx, query, max_price, max_pph, category, genre, exclude_genre, sort,
             search_title += f" in {category_name}"
     else:
         search_title = f"Search: {category_name or 'All'}"
-    _postprocess_and_output(
+    filtered, filter_breakdown, editions_removed, series_collapsed = _apply_filters(
         all_products,
-        title=search_title,
         max_price=max_price, min_rating=min_rating, min_ratings=min_ratings,
         min_hours=min_hours, narrator=narrator, author=author, exclude_authors=exclude_authors,
         exclude_narrators=exclude_narrators,
         language=language, on_sale=on_sale, skip_asins=skip_asins,
         exclude_category_ids=exclude_category_ids,
-        first_in_series=first_in_series, sort=sort, limit=limit,
-        output=output, json_flag=json_flag, quiet=quiet,
-        currency=cur, interactive=interactive, show_url=show_url, max_pph=max_pph,
+        do_first_in_series=first_in_series, sort=sort, max_pph=max_pph,
         min_discount=min_discount, series=series, publisher=publisher,
+    )
+    filtered, serialized, total_before_limit = _record_and_cache(
+        filtered, title=search_title, limit=limit,
+    )
+    _emit_output(
+        filtered, serialized,
+        title=search_title,
+        output=output, json_flag=json_flag, quiet=quiet,
+        max_price=max_price, filter_breakdown=filter_breakdown,
+        editions_removed=editions_removed, series_collapsed=series_collapsed,
+        total_before_limit=total_before_limit,
+        currency=cur, interactive=interactive, show_url=show_url,
     )
     display_query = queries[0] if len(queries) == 1 else None
     if display_query and not author and not json_flag and not quiet and looks_like_person_name(display_query):
@@ -778,18 +808,27 @@ def find(ctx, category, genre, exclude_genre, keywords, max_price, max_pph, sort
         find_title += f" in {category_name}"
     if keywords:
         find_title += f' matching "{keywords}"'
-    _postprocess_and_output(
+    filtered, filter_breakdown, editions_removed, series_collapsed = _apply_filters(
         all_products,
-        title=find_title,
         max_price=max_price, min_rating=min_rating, min_ratings=min_ratings,
         min_hours=min_hours, narrator=narrator, author=author, exclude_authors=exclude_authors,
         exclude_narrators=exclude_narrators,
         language=language, on_sale=on_sale, skip_asins=skip_asins,
         exclude_category_ids=exclude_category_ids,
-        first_in_series=first_in_series, sort=sort, limit=limit,
-        output=output, json_flag=json_flag, quiet=quiet,
-        currency=cur, interactive=interactive, show_url=show_url, max_pph=max_pph,
+        do_first_in_series=first_in_series, sort=sort, max_pph=max_pph,
         min_discount=min_discount, series=series, publisher=publisher,
+    )
+    filtered, serialized, total_before_limit = _record_and_cache(
+        filtered, title=find_title, limit=limit,
+    )
+    _emit_output(
+        filtered, serialized,
+        title=find_title,
+        output=output, json_flag=json_flag, quiet=quiet,
+        max_price=max_price, filter_breakdown=filter_breakdown,
+        editions_removed=editions_removed, series_collapsed=series_collapsed,
+        total_before_limit=total_before_limit,
+        currency=cur, interactive=interactive, show_url=show_url,
     )
 
 
@@ -1012,29 +1051,26 @@ def series(ctx, min_books, max_series, series_filter, max_price, min_rating, min
                     time.sleep(0.3)
 
     # 4. Post-process using shared pipeline
-    _postprocess_and_output(
+    series_title = f"Series Continuation Books ({len(invested_sorted)} series)"
+    filtered, filter_breakdown, editions_removed, series_collapsed = _apply_filters(
         all_candidates,
-        title=f"Series Continuation Books ({len(invested_sorted)} series)",
-        max_price=max_price,
-        min_rating=min_rating,
-        min_ratings=min_ratings,
-        min_hours=min_hours,
-        narrator="",
-        author="",
-        exclude_authors=(),
-        exclude_narrators=(),
-        language="",
-        on_sale=on_sale,
-        skip_asins=None,  # already filtered above
-        exclude_category_ids=set(),
-        first_in_series=False,
-        sort=sort,
-        limit=limit,
-        output=output,
-        json_flag=json_flag,
-        quiet=quiet,
-        currency=cur,
-        interactive=interactive,
+        max_price=max_price, min_rating=min_rating, min_ratings=min_ratings,
+        min_hours=min_hours, narrator="", author="",
+        exclude_authors=(), exclude_narrators=(), language="",
+        on_sale=on_sale, skip_asins=None, exclude_category_ids=set(),
+        do_first_in_series=False, sort=sort,
+    )
+    filtered, serialized, total_before_limit = _record_and_cache(
+        filtered, title=series_title, limit=limit,
+    )
+    _emit_output(
+        filtered, serialized,
+        title=series_title,
+        output=output, json_flag=json_flag, quiet=quiet,
+        max_price=max_price, filter_breakdown=filter_breakdown,
+        editions_removed=editions_removed, series_collapsed=series_collapsed,
+        total_before_limit=total_before_limit,
+        currency=cur, interactive=interactive,
     )
 
 
@@ -1108,19 +1144,27 @@ def last_cmd(ctx, sort, max_price, max_pph, min_rating, min_ratings, min_hours, 
 
     effective_sort = sort or ""  # preserve original cache order when no --sort given
     cur = LOCALE_CURRENCY.get(ctx.obj["locale"], "$")
-    _postprocess_and_output(
+    filtered, filter_breakdown, editions_removed, series_collapsed = _apply_filters(
         products,
-        title=cached_title,
         max_price=max_price, min_rating=min_rating, min_ratings=min_ratings,
         min_hours=min_hours, narrator=narrator, author=author, exclude_authors=exclude_authors,
         exclude_narrators=exclude_narrators,
         language=language, on_sale=on_sale, skip_asins=None,
         exclude_category_ids=set(),
-        first_in_series=first_in_series, sort=effective_sort, limit=limit,
+        do_first_in_series=first_in_series, sort=effective_sort, max_pph=max_pph,
+        min_discount=min_discount, series=series, publisher=publisher,
+    )
+    filtered, serialized, total_before_limit = _record_and_cache(
+        filtered, title=cached_title, write_cache=False, limit=limit,
+    )
+    _emit_output(
+        filtered, serialized,
+        title=cached_title,
         output=output, json_flag=json_flag, quiet=quiet,
-        currency=cur, interactive=interactive, write_cache=False,
-        show_url=show_url, max_pph=max_pph, min_discount=min_discount, series=series,
-        publisher=publisher,
+        max_price=max_price, filter_breakdown=filter_breakdown,
+        editions_removed=editions_removed, series_collapsed=series_collapsed,
+        total_before_limit=total_before_limit,
+        currency=cur, interactive=interactive, show_url=show_url,
     )
 
 

--- a/src/audible_deals/cli.py
+++ b/src/audible_deals/cli.py
@@ -79,6 +79,7 @@ from audible_deals.filtering import (  # noqa: F401 — re-exported for backward
     _sort_local,
     _value_score,
 )
+from audible_deals.settings import Settings
 from audible_deals.constants import _atomic_write  # noqa: F401 — re-exported for backward compat
 from audible_deals.utils import (  # noqa: F401 — re-exported for backward compat
     _looks_like_person_name,
@@ -137,54 +138,13 @@ def _safe_record_prices(products: list[Product]) -> None:
 _CL = click.core.ParameterSource.COMMANDLINE
 
 
-def _apply_config_defaults(ctx: click.Context, ns: dict, cfg: dict) -> None:
-    """Apply global config values to the command namespace for keys not set on the CLI.
-
-    ``ns`` is mutated in place. Uses ``ctx.get_parameter_source`` to detect CLI flags.
-    Handles ``max_price`` specially (falsy 0.0 is a valid price).
-    """
-    if cfg.get("max_price") is not None and ctx.get_parameter_source("max_price") != _CL:
-        ns["max_price"] = cfg["max_price"]
-    for key in ("sort", "pages"):
-        if cfg.get(key) is not None and ctx.get_parameter_source(key) != _CL:
-            ns[key] = cfg[key]
-    for key in ("min_rating", "min_ratings", "min_hours", "min_discount", "max_pph", "limit"):
-        if cfg.get(key) is not None and ctx.get_parameter_source(key) != _CL:
-            ns[key] = cfg[key]
-    for key in ("language", "narrator", "author", "series", "publisher"):
-        if cfg.get(key) is not None and ctx.get_parameter_source(key) != _CL:
-            ns[key] = cfg[key]
-    for flag in ("on_sale", "deep", "first_in_series", "all_languages", "skip_owned", "interactive"):
-        if cfg.get(flag) is not None and ctx.get_parameter_source(flag) != _CL:
-            ns[flag] = cfg[flag]
-
-
-def _apply_profile_defaults(ctx: click.Context, ns: dict, p: dict) -> None:
-    """Apply profile values to the command namespace for keys not set on the CLI.
-
-    ``ns`` is mutated in place. Profile values override config but not CLI flags.
-    """
-    for key in ("genre", "exclude_genre", "exclude_authors", "exclude_narrators", "keywords", "narrator", "author", "language", "series", "publisher"):
-        if ctx.get_parameter_source(key) != _CL and p.get(key) is not None:
-            ns[key] = p[key]
-    for key in ("max_price", "min_rating", "min_ratings", "min_hours", "min_discount", "max_pph", "limit"):
-        if ctx.get_parameter_source(key) != _CL and p.get(key) is not None:
-            ns[key] = p[key]
-    for key in ("sort", "pages"):
-        if ctx.get_parameter_source(key) != _CL and p.get(key) is not None:
-            ns[key] = p[key]
-    for flag in ("on_sale", "deep", "first_in_series", "all_languages", "skip_owned", "interactive"):
-        if p.get(flag) is not None and ctx.get_parameter_source(flag) != _CL:
-            ns[flag] = p[flag]
-
-
-def _resolve_defaults(ctx: click.Context, ns: dict, profile_name: str | None) -> None:
-    """Apply config defaults and optional profile to a command namespace.
-
-    Mutates *ns* in place. Used by both ``search`` and ``find`` to avoid
-    duplicating the config/profile loading logic.
-    """
-    _apply_config_defaults(ctx, ns, ctx.obj.get("config", {}))
+def _resolve_scan_settings(
+    ctx: click.Context,
+    profile_name: str | None,
+    cli_flags: dict,
+) -> dict:
+    """Merge config/profile/CLI and return an updated namespace dict."""
+    profile: dict | None = None
     if profile_name:
         profiles = _load_profiles()
         if profile_name not in profiles:
@@ -192,7 +152,24 @@ def _resolve_defaults(ctx: click.Context, ns: dict, profile_name: str | None) ->
                 f"Profile '{profile_name}' not found. "
                 "Use 'deals profile list' to see available profiles."
             )
-        _apply_profile_defaults(ctx, ns, profiles[profile_name])
+        profile = profiles[profile_name]
+    s = Settings.resolve(
+        ctx,
+        config=ctx.obj.get("config", {}),
+        profile=profile,
+        cli_flags=cli_flags,
+    )
+    # Write resolved settings back into the namespace dict
+    result = dict(cli_flags)
+    for key in (
+        "max_price", "sort", "pages", "min_rating", "min_ratings", "min_hours",
+        "min_discount", "max_pph", "limit", "language", "narrator", "author",
+        "series", "publisher", "on_sale", "deep", "first_in_series", "all_languages",
+        "skip_owned", "interactive", "genre", "exclude_genre", "exclude_authors",
+        "exclude_narrators", "keywords",
+    ):
+        result[key] = getattr(s, key)
+    return result
 
 
 def _resolve_categories(
@@ -499,13 +476,8 @@ def _build_scan_namespace(
     profile_name: str | None,
     **kwargs,
 ) -> dict:
-    """Build a resolved namespace dict from command kwargs + config/profile defaults.
-
-    Calls _resolve_defaults, applies quiet-on-export and language defaults.
-    Returns the resolved namespace dict ready for use.
-    """
-    ns = dict(kwargs)
-    _resolve_defaults(ctx, ns, profile_name)
+    """Build a resolved namespace dict from command kwargs + config/profile defaults."""
+    ns = _resolve_scan_settings(ctx, profile_name, dict(kwargs))
     if ns.get("output") and ctx.get_parameter_source("quiet") != _CL:
         ns["quiet"] = True
     if ns.get("json_flag"):
@@ -941,9 +913,10 @@ def series(ctx, min_books, max_series, series_filter, max_price, min_rating, min
     if json_flag:
         console.file = sys.stderr
 
-    ns = dict(max_price=max_price, min_rating=min_rating, min_ratings=min_ratings,
-              min_hours=min_hours, on_sale=on_sale, limit=limit, sort=sort, pages=pages)
-    _apply_config_defaults(ctx, ns, ctx.obj.get("config", {}))
+    ns = _resolve_scan_settings(ctx, None, dict(
+        max_price=max_price, min_rating=min_rating, min_ratings=min_ratings,
+        min_hours=min_hours, on_sale=on_sale, limit=limit, sort=sort, pages=pages,
+    ))
     max_price, min_rating, min_ratings = ns["max_price"], ns["min_rating"], ns["min_ratings"]
     min_hours, on_sale, limit = ns["min_hours"], ns["on_sale"], ns["limit"]
     sort, pages = ns["sort"], ns["pages"]

--- a/src/audible_deals/constants.py
+++ b/src/audible_deals/constants.py
@@ -88,6 +88,9 @@ CLIENT_SORT_OPTIONS = frozenset({"price", "-price", "discount", "price-per-hour"
 # All valid sort keys (server + client)
 ALL_SORT_OPTIONS = frozenset(SORT_OPTIONS.keys()) | CLIENT_SORT_OPTIONS
 
+DEFAULT_SORT = "price-per-hour"
+DEFAULT_LIMIT = 25
+
 # Sort orders used by --deep to maximize item coverage
 DEEP_SORT_ORDERS = ["BestSellers", "-ReleaseDate", "AvgRating"]
 

--- a/src/audible_deals/filtering.py
+++ b/src/audible_deals/filtering.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from audible_deals.client import Product
 
 
-def _filter_products(
+def filter_products(
     products: list[Product],
     *,
     max_price: float | None = None,
@@ -66,7 +66,7 @@ def _filter_products(
 
     if max_pph is not None:
         before = len(filtered)
-        filtered = [p for p in filtered if _price_per_hour(p) <= max_pph]
+        filtered = [p for p in filtered if price_per_hour(p) <= max_pph]
         if (removed := before - len(filtered)):
             breakdown["max $/hr"] = removed
 
@@ -182,14 +182,14 @@ def _filter_products(
     return filtered, breakdown
 
 
-def _price_per_hour(p: Product) -> float:
+def price_per_hour(p: Product) -> float:
     """Calculate price per hour of audio. Returns inf for missing data."""
     if p.price is None or p.hours <= 0:
         return float("inf")
     return p.price / p.hours
 
 
-def _value_score(p: Product) -> float:
+def value_score(p: Product) -> float:
     """Composite value score: (rating * hours) / price. Higher is better."""
     if p.price is None or p.hours <= 0 or p.rating <= 0:
         return 0.0
@@ -198,7 +198,7 @@ def _value_score(p: Product) -> float:
     return (p.rating * p.hours) / p.price
 
 
-def _sort_local(products: list[Product], sort: str) -> list[Product]:
+def sort_local(products: list[Product], sort: str) -> list[Product]:
     """Re-sort locally when combining pages (server sort is per-page)."""
     if sort == "price":
         return sorted(products, key=lambda p: (p.price if p.price is not None else 9999))
@@ -217,9 +217,9 @@ def _sort_local(products: list[Product], sort: str) -> list[Product]:
             reverse=True,
         )
     elif sort == "price-per-hour":
-        return sorted(products, key=_price_per_hour)
+        return sorted(products, key=price_per_hour)
     elif sort == "value":
-        return sorted(products, key=lambda p: (_value_score(p), p.rating), reverse=True)
+        return sorted(products, key=lambda p: (value_score(p), p.rating), reverse=True)
     elif sort == "title":
         return sorted(products, key=lambda p: p.title.lower())
     elif sort == "author":
@@ -231,7 +231,7 @@ def _sort_local(products: list[Product], sort: str) -> list[Product]:
     return products
 
 
-def _dedupe_editions(products: list[Product]) -> tuple[list[Product], int]:
+def dedupe_editions(products: list[Product]) -> tuple[list[Product], int]:
     """Remove duplicate editions of the same book (same series + position).
 
     Keeps the cheapest edition. Always-on — no flag needed.
@@ -271,7 +271,7 @@ def _series_pos(p: Product) -> float:
         return float("inf")
 
 
-def _first_in_series(products: list[Product]) -> tuple[list[Product], int]:
+def first_in_series(products: list[Product]) -> tuple[list[Product], int]:
     """Keep only the lowest-position item per series (must be <= 1.0).
 
     Non-series items pass through unchanged. Series whose lowest-available

--- a/src/audible_deals/serialization.py
+++ b/src/audible_deals/serialization.py
@@ -11,10 +11,10 @@ from pathlib import Path
 import click
 
 from audible_deals.client import Product
-from audible_deals.filtering import _price_per_hour
+from audible_deals.filtering import price_per_hour
 
 
-def _serialize_product(p: Product) -> dict:
+def serialize_product(p: Product) -> dict:
     """Convert a Product to a plain dict for export."""
     d = asdict(p)
     if d["price"] is not None:
@@ -24,27 +24,27 @@ def _serialize_product(p: Product) -> dict:
     d["full_title"] = p.full_title
     d["hours"] = p.hours
     d["discount_pct"] = p.discount_pct
-    pph = _price_per_hour(p)
+    pph = price_per_hour(p)
     d["price_per_hour"] = round(pph, 2) if pph != float("inf") else None
     d["url"] = p.url
     return d
 
 
-_PRODUCT_FIELDS: frozenset[str] = frozenset(f.name for f in dataclasses.fields(Product))
+PRODUCT_FIELDS: frozenset[str] = frozenset(f.name for f in dataclasses.fields(Product))
 
 
-def _deserialize_product(d: dict) -> Product | None:
+def deserialize_product(d: dict) -> Product | None:
     """Reconstruct a Product from a serialized dict, ignoring computed fields."""
     try:
-        return Product(**{k: v for k, v in d.items() if k in _PRODUCT_FIELDS})
+        return Product(**{k: v for k, v in d.items() if k in PRODUCT_FIELDS})
     except TypeError:
         return None
 
 
-def _export_products(products: list[Product], path: Path) -> None:
+def export_products(products: list[Product], path: Path) -> None:
     """Export products to file, detecting format from extension."""
     suffix = path.suffix.lower()
-    rows = [_serialize_product(p) for p in products]
+    rows = [serialize_product(p) for p in products]
 
     if suffix == ".json":
         path.write_text(json_mod.dumps(rows, indent=2, ensure_ascii=False))

--- a/src/audible_deals/settings.py
+++ b/src/audible_deals/settings.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import click
 
+from audible_deals.constants import DEFAULT_LIMIT, DEFAULT_SORT
+
 
 _CL = click.core.ParameterSource.COMMANDLINE
 
@@ -52,14 +54,14 @@ class Settings:
     """Fully-resolved options for a scan command."""
 
     max_price: float | None = None
-    sort: str = "price-per-hour"
+    sort: str = DEFAULT_SORT
     pages: int = 10
     min_rating: float = 0.0
     min_ratings: int = 0
     min_hours: float = 0.0
     min_discount: int = 0
     max_pph: float | None = None
-    limit: int | None = 25
+    limit: int | None = DEFAULT_LIMIT
     language: str = ""
     narrator: str = ""
     author: str = ""

--- a/src/audible_deals/settings.py
+++ b/src/audible_deals/settings.py
@@ -1,0 +1,107 @@
+"""Resolved scan settings as a frozen dataclass.
+
+Merges defaults <- config_file <- profile <- CLI flags in a single pass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any
+
+import click
+
+
+_CL = click.core.ParameterSource.COMMANDLINE
+
+# Keys covered by config-file defaults
+_CONFIG_KEYS: tuple[str, ...] = (
+    "max_price",
+    "sort",
+    "pages",
+    "min_rating",
+    "min_ratings",
+    "min_hours",
+    "min_discount",
+    "max_pph",
+    "limit",
+    "language",
+    "narrator",
+    "author",
+    "series",
+    "publisher",
+    "on_sale",
+    "deep",
+    "first_in_series",
+    "all_languages",
+    "skip_owned",
+    "interactive",
+)
+
+# Additional keys that only profiles supply (not in config schema)
+_PROFILE_EXTRA_KEYS: tuple[str, ...] = (
+    "genre",
+    "exclude_genre",
+    "exclude_authors",
+    "exclude_narrators",
+    "keywords",
+)
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Fully-resolved options for a scan command."""
+
+    max_price: float | None = None
+    sort: str = "price-per-hour"
+    pages: int = 10
+    min_rating: float = 0.0
+    min_ratings: int = 0
+    min_hours: float = 0.0
+    min_discount: int = 0
+    max_pph: float | None = None
+    limit: int | None = 25
+    language: str = ""
+    narrator: str = ""
+    author: str = ""
+    series: str = ""
+    publisher: str = ""
+    on_sale: bool = False
+    deep: bool = False
+    first_in_series: bool = False
+    all_languages: bool = False
+    skip_owned: bool = False
+    interactive: bool = False
+    genre: str = ""
+    exclude_genre: tuple[str, ...] = ()
+    exclude_authors: tuple[str, ...] = ()
+    exclude_narrators: tuple[str, ...] = ()
+    keywords: str = ""
+
+    @classmethod
+    def resolve(
+        cls,
+        ctx: click.Context,
+        *,
+        config: dict[str, Any],
+        profile: dict[str, Any] | None,
+        cli_flags: dict[str, Any],
+    ) -> "Settings":
+        """Return a Settings built from merged cli_flags <- config <- profile <- cli_flags.
+
+        Precedence (highest wins): CLI > profile > config > dataclass defaults.
+        Only overrides when the source is not COMMANDLINE.
+        """
+        merged: dict[str, Any] = dict(cli_flags)
+
+        for key in _CONFIG_KEYS:
+            if config.get(key) is not None and ctx.get_parameter_source(key) != _CL:
+                merged[key] = config[key]
+
+        if profile:
+            for key in _CONFIG_KEYS + _PROFILE_EXTRA_KEYS:
+                if profile.get(key) is not None and ctx.get_parameter_source(key) != _CL:
+                    merged[key] = profile[key]
+
+        known = {f.name for f in fields(cls)}
+        kwargs = {k: v for k, v in merged.items() if k in known}
+        return cls(**kwargs)

--- a/src/audible_deals/state.py
+++ b/src/audible_deals/state.py
@@ -32,7 +32,7 @@ from audible_deals.constants import (
 # ---------------------------------------------------------------------------
 
 
-def _load_wishlist() -> list[dict]:
+def load_wishlist() -> list[dict]:
     if WISHLIST_FILE.exists():
         try:
             data = json_mod.loads(WISHLIST_FILE.read_text())
@@ -43,11 +43,11 @@ def _load_wishlist() -> list[dict]:
     return []
 
 
-def _save_wishlist(items: list[dict]) -> None:
+def save_wishlist(items: list[dict]) -> None:
     _atomic_write(WISHLIST_FILE, json_mod.dumps(items, indent=2, ensure_ascii=False))
 
 
-def _wishlist_entry(product: Product, max_price: float | None) -> dict:
+def wishlist_entry(product: Product, max_price: float | None) -> dict:
     """Build a wishlist dict from a Product."""
     return {
         "asin": product.asin,
@@ -62,7 +62,7 @@ def _wishlist_entry(product: Product, max_price: float | None) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _load_profiles() -> dict[str, dict]:
+def load_profiles() -> dict[str, dict]:
     if PROFILES_FILE.exists():
         try:
             data = json_mod.loads(PROFILES_FILE.read_text())
@@ -73,7 +73,7 @@ def _load_profiles() -> dict[str, dict]:
     return {}
 
 
-def _save_profiles(profiles: dict[str, dict]) -> None:
+def save_profiles(profiles: dict[str, dict]) -> None:
     _atomic_write(PROFILES_FILE, json_mod.dumps(profiles, indent=2, ensure_ascii=False))
 
 
@@ -82,7 +82,7 @@ def _save_profiles(profiles: dict[str, dict]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _load_config() -> dict:
+def load_config() -> dict:
     if CONFIG_FILE.exists():
         try:
             data = json_mod.loads(CONFIG_FILE.read_text())
@@ -93,11 +93,11 @@ def _load_config() -> dict:
     return {}
 
 
-def _save_config(cfg: dict) -> None:
+def save_config(cfg: dict) -> None:
     _atomic_write(CONFIG_FILE, json_mod.dumps(cfg, indent=2, ensure_ascii=False))
 
 
-def _coerce_config_value(key: str, raw: str):
+def coerce_config_value(key: str, raw: str):
     """Coerce a raw string value to the type declared in _CONFIG_SCHEMA."""
     typ = _CONFIG_SCHEMA[key]
     if typ is bool:
@@ -124,7 +124,7 @@ def _coerce_config_value(key: str, raw: str):
         raise click.ClickException(f"Invalid value for '{key}' (expected {typ.__name__}): {e}")
 
 
-def _validate_config_key(key: str) -> str:
+def validate_config_key(key: str) -> str:
     """Normalize and validate a config key. Returns the snake_case key or raises."""
     norm = key.replace("-", "_")
     if norm not in _CONFIG_SCHEMA:
@@ -138,7 +138,7 @@ def _validate_config_key(key: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _load_seen_asins() -> set[str]:
+def load_seen_asins() -> set[str]:
     """Load cumulative seen ASINs for exclusion."""
     try:
         data = json_mod.loads(SEEN_ASINS_FILE.read_text())
@@ -149,11 +149,11 @@ def _load_seen_asins() -> set[str]:
     return set()
 
 
-def _save_seen_asins(new_asins: set[str]) -> None:
+def save_seen_asins(new_asins: set[str]) -> None:
     """Append ASINs to the cumulative seen-ASINs file."""
     if not new_asins:
         return
-    existing = _load_seen_asins()
+    existing = load_seen_asins()
     if new_asins <= existing:
         return
     merged = sorted(existing | new_asins)
@@ -163,11 +163,11 @@ def _save_seen_asins(new_asins: set[str]) -> None:
         pass
 
 
-def _merge_seen_asins(skip_asins: set[str] | None, exclude_seen: bool) -> set[str] | None:
+def merge_seen_asins(skip_asins: set[str] | None, exclude_seen: bool) -> set[str] | None:
     """Merge previously-seen ASINs into the skip set when --exclude-seen is active."""
     if not exclude_seen:
         return skip_asins
-    seen = _load_seen_asins()
+    seen = load_seen_asins()
     if skip_asins is None:
         return seen
     return skip_asins | seen
@@ -178,7 +178,7 @@ def _merge_seen_asins(skip_asins: set[str] | None, exclude_seen: bool) -> set[st
 # ---------------------------------------------------------------------------
 
 
-def _load_last_results() -> tuple[str, list[dict]]:
+def load_last_results() -> tuple[str, list[dict]]:
     """Load the last results cache from disk.
 
     Returns (title, products) where title is the original query context.
@@ -201,9 +201,9 @@ def _load_last_results() -> tuple[str, list[dict]]:
     raise click.ClickException("Last results cache is corrupt.")
 
 
-def _resolve_last_references(refs: tuple[int, ...]) -> list[tuple[str, str]]:
+def resolve_last_references(refs: tuple[int, ...]) -> list[tuple[str, str]]:
     """Convert 1-indexed position references to (asin, description) tuples from the last results cache."""
-    title, data = _load_last_results()
+    title, data = load_last_results()
     results: list[tuple[str, str]] = []
     for ref in refs:
         if ref < 1 or ref > len(data):
@@ -225,7 +225,7 @@ def _resolve_last_references(refs: tuple[int, ...]) -> list[tuple[str, str]]:
 _history_dir_created = False
 
 
-def _record_prices(products: list[Product]) -> None:
+def record_prices(products: list[Product]) -> None:
     """Append today's prices to per-ASIN history files.
 
     Batches writes: reads all existing files, updates in-memory,
@@ -266,13 +266,13 @@ def _record_prices(products: list[Product]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _save_last_results(title: str, serialized: list[dict]) -> None:
+def save_last_results(title: str, serialized: list[dict]) -> None:
     """Write serialized products to the last-results cache."""
     cache_obj = {"title": title, "results": serialized}
     _atomic_write(LAST_RESULTS_FILE, json_mod.dumps(cache_obj, ensure_ascii=False))
 
 
-def _clear_last_results() -> bool:
+def clear_last_results() -> bool:
     """Delete the last-results cache. Returns True if deleted."""
     try:
         LAST_RESULTS_FILE.unlink()
@@ -281,7 +281,7 @@ def _clear_last_results() -> bool:
         return False
 
 
-def _clear_seen_asins() -> bool:
+def clear_seen_asins() -> bool:
     """Delete the cumulative seen-ASINs file. Returns True if deleted."""
     try:
         SEEN_ASINS_FILE.unlink()
@@ -295,12 +295,12 @@ def _clear_seen_asins() -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _has_price_history() -> bool:
+def has_price_history() -> bool:
     """Return True if the price history directory exists."""
     return HISTORY_DIR.exists()
 
 
-def _load_price_history(asin: str) -> list[dict]:
+def load_price_history(asin: str) -> list[dict]:
     """Load price history entries for a single ASIN.
 
     Returns an empty list if the file doesn't exist or is corrupt.
@@ -315,7 +315,7 @@ def _load_price_history(asin: str) -> list[dict]:
         return []
 
 
-def _scan_price_changes(
+def scan_price_changes(
     days: int,
 ) -> tuple[list[tuple[str, str, float, float]], list[tuple[str, str, float]]]:
     """Scan history files for price drops and newly tracked items.
@@ -370,17 +370,17 @@ def _scan_price_changes(
     return drops, new_items
 
 
-def _find_wishlist_hits() -> list[dict]:
+def find_wishlist_hits() -> list[dict]:
     """Find wishlist items whose latest tracked price is at or below target.
 
     Returns matching wishlist entry dicts.
     """
-    wishlist_items = _load_wishlist()
+    wishlist_items = load_wishlist()
     hits: list[dict] = []
     for item in wishlist_items:
         if not _ASIN_RE.fullmatch(item.get("asin", "")):
             continue
-        entries = _load_price_history(item["asin"])
+        entries = load_price_history(item["asin"])
         if entries and item.get("max_price") is not None and entries[-1]["price"] <= item["max_price"]:
             hits.append(item)
     return hits

--- a/src/audible_deals/utils.py
+++ b/src/audible_deals/utils.py
@@ -16,13 +16,13 @@ import click
 from audible_deals.constants import _ASIN_RE
 
 
-def _validate_asin(asin: str) -> None:
+def validate_asin(asin: str) -> None:
     """Validate that an ASIN is alphanumeric and won't cause path traversal."""
     if not _ASIN_RE.fullmatch(asin):
         raise click.BadParameter(f"Invalid ASIN format: {asin!r}")
 
 
-def _validate_webhook_url(url: str) -> None:
+def validate_webhook_url(url: str) -> None:
     """Validate webhook URL: must be http(s) and must not resolve to private IPs."""
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme not in ("http", "https"):
@@ -58,7 +58,7 @@ _NAME_STOPWORDS = frozenset({
 })
 
 
-def _looks_like_person_name(query: str) -> bool:
+def looks_like_person_name(query: str) -> bool:
     """Return True if query looks like a 2-3 word person name (each word Title-cased)."""
     words = query.strip().split()
     if len(words) < 2 or len(words) > 3:
@@ -68,7 +68,7 @@ def _looks_like_person_name(query: str) -> bool:
     return all(w[0].isupper() for w in words)
 
 
-def _parse_interval(value: str) -> int:
+def parse_interval(value: str) -> int:
     """Parse an interval string into seconds. Accepts '30m', '2h', '1h30m', '90s', or a plain number (minutes)."""
     raw = value
     value = value.strip().lower()

--- a/tests/test_all_routes.py
+++ b/tests/test_all_routes.py
@@ -41,7 +41,7 @@ def _setup_library_mock(mock_client, products):
 
 def _seed_last_results(tmp_config, products):
     """Write a last_results.json cache file."""
-    from audible_deals.serialization import _serialize_product
+    from audible_deals.serialization import serialize_product as _serialize_product
     data = {
         "title": "Test Results",
         "results": [_serialize_product(p) for p in products],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,23 +10,31 @@ import pytest
 from click.testing import CliRunner
 
 from audible_deals.cli import (
-    _validate_webhook_url,
-    _dedupe_editions,
-    _deserialize_product,
-    _export_products,
     _fetch_with_progress,
-    _filter_products,
-    _first_in_series,
-    _load_seen_asins,
-    _save_seen_asins,
-    _looks_like_person_name,
-    _parse_interval,
-    _price_per_hour,
-    _resolve_last_references,
-    _serialize_product,
-    _sort_local,
-    _value_score,
     cli,
+)
+from audible_deals.filtering import (
+    dedupe_editions as _dedupe_editions,
+    filter_products as _filter_products,
+    first_in_series as _first_in_series,
+    price_per_hour as _price_per_hour,
+    sort_local as _sort_local,
+    value_score as _value_score,
+)
+from audible_deals.serialization import (
+    deserialize_product as _deserialize_product,
+    export_products as _export_products,
+    serialize_product as _serialize_product,
+)
+from audible_deals.state import (
+    load_seen_asins as _load_seen_asins,
+    save_seen_asins as _save_seen_asins,
+    resolve_last_references as _resolve_last_references,
+)
+from audible_deals.utils import (
+    looks_like_person_name as _looks_like_person_name,
+    parse_interval as _parse_interval,
+    validate_webhook_url as _validate_webhook_url,
 )
 from audible_deals.client import Product
 from tests.conftest import make_product
@@ -600,7 +608,7 @@ class TestWishlistSyncCommand:
     def test_sync_skips_existing(self, mock_client, tmp_config):
         """Items already in local wishlist are counted as skipped, not re-added."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "WS1", "title": "Already Here", "max_price": None, "added": ""},
         ])
         mock_client.get_wishlist.return_value = [
@@ -634,7 +642,7 @@ class TestWishlistSyncCommand:
 
         # Verify the saved item has max_price set
         import audible_deals.cli as cli_mod
-        items = cli_mod._load_wishlist()
+        items = cli_mod.load_wishlist()
         assert len(items) == 1
         assert items[0]["asin"] == "WS3"
         assert items[0]["max_price"] == 7.99
@@ -655,7 +663,7 @@ class TestWishlistSyncCommand:
     def test_sync_update_changes_existing_price(self, mock_client, tmp_config):
         """--update with --max-price updates target price for existing items."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "WS1", "title": "Old Price Book", "max_price": 20.0, "added": ""},
         ])
         mock_client.get_wishlist.return_value = [
@@ -664,7 +672,7 @@ class TestWishlistSyncCommand:
         runner = CliRunner()
         result = runner.invoke(cli, ["wishlist", "sync", "--max-price", "5", "--update"])
         assert result.exit_code == 0, result.output
-        items = cli_mod._load_wishlist()
+        items = cli_mod.load_wishlist()
         assert items[0]["max_price"] == 5.0
         assert "1 updated" in result.output
 
@@ -740,19 +748,19 @@ class TestLoadWishlistTypeValidation:
         """A wishlist.json containing {} instead of [] returns empty list."""
         import audible_deals.cli as cli_mod
         cli_mod.WISHLIST_FILE.write_text("{}")
-        assert cli_mod._load_wishlist() == []
+        assert cli_mod.load_wishlist() == []
 
     def test_load_profiles_list_returns_empty_dict(self, tmp_config):
         """A profiles.json containing [] instead of {} returns empty dict."""
         import audible_deals.cli as cli_mod
         cli_mod.PROFILES_FILE.write_text("[]")
-        assert cli_mod._load_profiles() == {}
+        assert cli_mod.load_profiles() == {}
 
     def test_load_config_array_returns_empty_dict(self, tmp_config):
         """A config.json containing a JSON array instead of {} returns {}."""
-        from audible_deals.state import _load_config
+        from audible_deals.state import load_config
         (tmp_config / "config.json").write_text("[1, 2]")
-        assert _load_config() == {}
+        assert load_config() == {}
 
 
 class TestWatchCommand:
@@ -765,7 +773,7 @@ class TestWatchCommand:
     def test_watch_with_items(self, mock_client, tmp_config):
         # Seed the wishlist
         import audible_deals.cli as cli_mod
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "W1", "title": "Book", "max_price": 10.0},
         ])
         mock_client.get_products_batch.return_value = [
@@ -780,7 +788,7 @@ class TestWatchCommand:
     def test_watch_buy_only(self, mock_client, tmp_config):
         """--buy-only filters to only items at or below target."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "W1", "title": "Cheap Book", "max_price": 10.0},
             {"asin": "W2", "title": "Expensive Book", "max_price": 3.0},
         ])
@@ -797,7 +805,7 @@ class TestWatchCommand:
     def test_watch_sort_by_title(self, mock_client, tmp_config):
         """--sort title orders output alphabetically."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "W1", "title": "Zebra Book", "max_price": 10.0},
             {"asin": "W2", "title": "Alpha Book", "max_price": 10.0},
         ])
@@ -817,7 +825,7 @@ class TestWatchCommand:
         from io import StringIO
         from rich.console import Console
         import audible_deals.cli as cli_mod
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "W1", "title": "URL Book", "max_price": 10.0},
         ])
         mock_client.get_products_batch.return_value = [
@@ -847,7 +855,7 @@ class TestWatchCommand:
     def test_watch_sort_keys(self, mock_client, tmp_config, sort_key):
         """--sort author and --sort asin run without error."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "W1", "title": "Book A", "max_price": 10.0},
             {"asin": "W2", "title": "Book B", "max_price": 10.0},
         ])
@@ -868,7 +876,7 @@ class TestHistoryCommand:
         assert "No price history" in result.output
 
     def test_history_after_recording(self, tmp_config, mock_client):
-        from audible_deals.cli import _record_prices
+        from audible_deals.state import record_prices as _record_prices
         products = [make_product(asin="H1", price=5.99)]
         _record_prices(products)
 
@@ -878,7 +886,7 @@ class TestHistoryCommand:
         assert "$5.99" in result.output
 
     def test_history_idempotent(self, tmp_config):
-        from audible_deals.cli import _record_prices
+        from audible_deals.state import record_prices as _record_prices
         products = [make_product(asin="H2", price=3.00)]
         _record_prices(products)
         _record_prices(products)  # Same day
@@ -1241,7 +1249,7 @@ class TestProfileSaveNewFlags:
         result = runner.invoke(cli, ["profile", "save", "myprofile", "--skip-owned"])
         assert result.exit_code == 0, result.output
         import audible_deals.cli as cli_mod
-        profiles = cli_mod._load_profiles()
+        profiles = cli_mod.load_profiles()
         assert profiles["myprofile"]["skip_owned"] is True
 
     def test_language_in_profile(self, tmp_config):
@@ -1249,7 +1257,7 @@ class TestProfileSaveNewFlags:
         result = runner.invoke(cli, ["profile", "save", "langprofile", "--language", "french"])
         assert result.exit_code == 0, result.output
         import audible_deals.cli as cli_mod
-        profiles = cli_mod._load_profiles()
+        profiles = cli_mod.load_profiles()
         assert profiles["langprofile"]["language"] == "french"
 
     def test_interactive_in_profile(self, tmp_config):
@@ -1257,7 +1265,7 @@ class TestProfileSaveNewFlags:
         result = runner.invoke(cli, ["profile", "save", "iprofile", "--interactive"])
         assert result.exit_code == 0, result.output
         import audible_deals.cli as cli_mod
-        profiles = cli_mod._load_profiles()
+        profiles = cli_mod.load_profiles()
         assert profiles["iprofile"]["interactive"] is True
 
 
@@ -1265,7 +1273,7 @@ class TestFindProfileSkipOwned:
     def test_find_profile_skip_owned(self, mock_client, tmp_config):
         """find --profile loads skip_owned from profile and calls get_library_asins."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({"myp": {"skip_owned": True}})
+        cli_mod.save_profiles({"myp": {"skip_owned": True}})
         mock_client.search_pages.return_value = iter([([], 1, 0)])
         mock_client.get_library_asins.return_value = set()
 
@@ -1277,7 +1285,7 @@ class TestFindProfileSkipOwned:
     def test_find_backward_compat(self, mock_client, tmp_config):
         """Old profiles without new keys still work fine."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({"oldp": {"max_price": 5.0}})
+        cli_mod.save_profiles({"oldp": {"max_price": 5.0}})
         mock_client.search_pages.return_value = iter([([], 1, 0)])
 
         runner = CliRunner()
@@ -1289,7 +1297,7 @@ class TestSearchWithProfile:
     def test_search_profile_applies_settings(self, mock_client, tmp_config):
         """search --profile X applies profile settings."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({"stest": {"min_rating": 4.5}})
+        cli_mod.save_profiles({"stest": {"min_rating": 4.5}})
         products = [
             make_product(asin="SP1", price=5.0, rating=4.8),
             make_product(asin="SP2", price=5.0, rating=3.0),
@@ -1316,7 +1324,7 @@ class TestSearchWithProfile:
     def test_search_profile_skip_owned(self, mock_client, tmp_config):
         """search --profile with skip_owned calls get_library_asins."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({"owned_profile": {"skip_owned": True}})
+        cli_mod.save_profiles({"owned_profile": {"skip_owned": True}})
         mock_client.search_pages.return_value = iter([([], 1, 0)])
         mock_client.get_library_asins.return_value = set()
 
@@ -1348,7 +1356,7 @@ class TestConfigCommands:
         result = runner.invoke(cli, ["config", "set", "skip-owned", "true"])
         assert result.exit_code == 0, result.output
         import audible_deals.cli as cli_mod
-        cfg = cli_mod._load_config()
+        cfg = cli_mod.load_config()
         assert cfg["skip_owned"] is True
 
     def test_set_invalid_bool(self, tmp_config):
@@ -1371,7 +1379,7 @@ class TestConfigCommands:
 
     def test_list_with_values(self, tmp_config):
         import audible_deals.cli as cli_mod
-        cli_mod._save_config({"max_price": 5.0, "skip_owned": True})
+        cli_mod.save_config({"max_price": 5.0, "skip_owned": True})
         runner = CliRunner()
         result = runner.invoke(cli, ["config", "list"])
         assert result.exit_code == 0, result.output
@@ -1380,21 +1388,21 @@ class TestConfigCommands:
 
     def test_reset_key(self, tmp_config):
         import audible_deals.cli as cli_mod
-        cli_mod._save_config({"max_price": 5.0, "min_rating": 4.0})
+        cli_mod.save_config({"max_price": 5.0, "min_rating": 4.0})
         runner = CliRunner()
         result = runner.invoke(cli, ["config", "reset", "max-price"])
         assert result.exit_code == 0, result.output
-        cfg = cli_mod._load_config()
+        cfg = cli_mod.load_config()
         assert "max_price" not in cfg
         assert "min_rating" in cfg
 
     def test_reset_all(self, tmp_config):
         import audible_deals.cli as cli_mod
-        cli_mod._save_config({"max_price": 5.0, "min_rating": 4.0})
+        cli_mod.save_config({"max_price": 5.0, "min_rating": 4.0})
         runner = CliRunner()
         result = runner.invoke(cli, ["config", "reset"], input="y\n")
         assert result.exit_code == 0, result.output
-        cfg = cli_mod._load_config()
+        cfg = cli_mod.load_config()
         assert cfg == {}
 
     def test_reset_invalid_key(self, tmp_config):
@@ -1408,7 +1416,7 @@ class TestConfigCommands:
         result = runner.invoke(cli, ["config", "set", "pages", "5"])
         assert result.exit_code == 0, result.output
         import audible_deals.cli as cli_mod
-        cfg = cli_mod._load_config()
+        cfg = cli_mod.load_config()
         assert cfg["pages"] == 5
         assert isinstance(cfg["pages"], int)
 
@@ -1417,7 +1425,7 @@ class TestConfigCommands:
         result = runner.invoke(cli, ["config", "set", "min-rating", "4.5"])
         assert result.exit_code == 0, result.output
         import audible_deals.cli as cli_mod
-        cfg = cli_mod._load_config()
+        cfg = cli_mod.load_config()
         assert cfg["min_rating"] == 4.5
 
 
@@ -1425,7 +1433,7 @@ class TestConfigAppliedToFind:
     def test_config_max_price_applies(self, mock_client, tmp_config):
         """Config max_price is applied when not passed on CLI."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_config({"max_price": 3.0})
+        cli_mod.save_config({"max_price": 3.0})
         products = [
             make_product(asin="CF1", price=2.0, series_name="", series_position=""),
             make_product(asin="CF2", price=6.0, series_name="", series_position=""),
@@ -1445,7 +1453,7 @@ class TestConfigAppliedToFind:
     def test_cli_flag_overrides_config(self, mock_client, tmp_config):
         """CLI --max-price overrides config max_price."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_config({"max_price": 2.0})
+        cli_mod.save_config({"max_price": 2.0})
         products = [
             make_product(asin="CO1", price=4.0, series_name="", series_position=""),
         ]
@@ -1465,8 +1473,8 @@ class TestConfigAppliedToFind:
     def test_profile_overrides_config(self, mock_client, tmp_config):
         """Profile min_rating overrides config min_rating."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_config({"min_rating": 4.0})
-        cli_mod._save_profiles({"p": {"min_rating": 3.0}})
+        cli_mod.save_config({"min_rating": 4.0})
+        cli_mod.save_profiles({"p": {"min_rating": 3.0}})
         products = [
             make_product(asin="PO1", price=3.0, rating=3.5, series_name="", series_position=""),
         ]
@@ -1735,7 +1743,7 @@ class TestExcludeAuthorFilter:
         ])
         assert result.exit_code == 0, result.output
         import audible_deals.cli as cli_mod
-        profiles = cli_mod._load_profiles()
+        profiles = cli_mod.load_profiles()
         assert "no-weir" in profiles
         excluded = profiles["no-weir"]["exclude_authors"]
         assert "Andy Weir" in excluded
@@ -1744,7 +1752,7 @@ class TestExcludeAuthorFilter:
     def test_find_profile_exclude_author_applied(self, mock_client, tmp_config):
         """find --profile with exclude_authors actually filters out the author."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({"no-weir": {"exclude_authors": ["Andy Weir"]}})
+        cli_mod.save_profiles({"no-weir": {"exclude_authors": ["Andy Weir"]}})
         products = [
             make_product(asin="EA1", price=3.0, authors=["Andy Weir"], series_name="", series_position=""),
             make_product(asin="EA2", price=3.0, authors=["Pierce Brown"], series_name="", series_position=""),
@@ -1844,7 +1852,7 @@ class TestAuthorFilter:
         result = runner.invoke(cli, ["profile", "save", "weir-profile", "--author", "Andy Weir"])
         assert result.exit_code == 0, result.output
         import audible_deals.cli as cli_mod
-        profiles = cli_mod._load_profiles()
+        profiles = cli_mod.load_profiles()
         assert profiles["weir-profile"]["author"] == "Andy Weir"
 
     def test_author_in_config(self, tmp_config):
@@ -2043,7 +2051,7 @@ class TestRecapWithTitles:
 
     def test_recap_title_stored_in_record_prices(self, tmp_config):
         """_record_prices stores the title in history entries."""
-        from audible_deals.cli import _record_prices
+        from audible_deals.state import record_prices as _record_prices
         p = make_product(asin="RC01", price=5.99, title="My Title Book")
         _record_prices([p])
 
@@ -2163,7 +2171,7 @@ class TestWatchEveryFlag:
     def test_watch_without_every_runs_once(self, mock_client, tmp_config):
         """watch without --every does a single check and exits."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_wishlist([{"asin": "W1", "title": "Test", "max_price": 10.0, "added": ""}])
+        cli_mod.save_wishlist([{"asin": "W1", "title": "Test", "max_price": 10.0, "added": ""}])
         mock_client.get_products_batch.return_value = [
             make_product(asin="W1", price=5.0, title="Test"),
         ]
@@ -2498,7 +2506,7 @@ class TestExcludeNarratorFilter:
         ])
         assert result.exit_code == 0, result.output
         import audible_deals.cli as cli_mod
-        profiles = cli_mod._load_profiles()
+        profiles = cli_mod.load_profiles()
         assert "no-bray" in profiles
         excluded = profiles["no-bray"]["exclude_narrators"]
         assert "R.C. Bray" in excluded
@@ -2563,7 +2571,7 @@ class TestSearchQueryOptional:
 class TestProfileShow:
     def test_profile_show_displays_flags(self, tmp_config):
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({
+        cli_mod.save_profiles({
             "myprofile": {
                 "genre": "sci-fi",
                 "max_price": 5.0,
@@ -2586,7 +2594,7 @@ class TestProfileShow:
 
     def test_profile_show_list_values(self, tmp_config):
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({
+        cli_mod.save_profiles({
             "multi": {
                 "exclude_authors": ["Andy Weir", "Brandon Sanderson"],
             }
@@ -2600,7 +2608,7 @@ class TestProfileShow:
     def test_profile_show_bool_true_displayed(self, tmp_config):
         """Boolean True values should show as --flag."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({
+        cli_mod.save_profiles({
             "booltest": {
                 "deep": True,
             }
@@ -2613,7 +2621,7 @@ class TestProfileShow:
     def test_profile_show_bool_false_displayed_as_no_flag(self, tmp_config):
         """Boolean False values should display as --no-flag."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({
+        cli_mod.save_profiles({
             "falsetest": {
                 "deep": False,
                 "on_sale": False,
@@ -2688,7 +2696,7 @@ class TestNotifyEmptyWishlist:
         """notify with items on wishlist but no hits outputs empty JSON object."""
         import json
         import audible_deals.cli as cli_mod
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "NT1", "title": "Some Book", "max_price": 5.0, "added": ""},
         ])
         mock_client.get_products_batch.return_value = [
@@ -2740,7 +2748,7 @@ class TestProfileShowSingularFlags:
     def test_exclude_authors_shows_as_exclude_author(self, tmp_config):
         """profile show renders exclude_authors as --exclude-author (singular)."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({"myp": {"exclude_authors": ["Andy Weir", "Terry Brooks"]}})
+        cli_mod.save_profiles({"myp": {"exclude_authors": ["Andy Weir", "Terry Brooks"]}})
         runner = CliRunner()
         result = runner.invoke(cli, ["profile", "show", "myp"])
         assert result.exit_code == 0, result.output
@@ -2750,7 +2758,7 @@ class TestProfileShowSingularFlags:
     def test_exclude_narrators_shows_as_exclude_narrator(self, tmp_config):
         """profile show renders exclude_narrators as --exclude-narrator (singular)."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({"myp2": {"exclude_narrators": ["R.C. Bray"]}})
+        cli_mod.save_profiles({"myp2": {"exclude_narrators": ["R.C. Bray"]}})
         runner = CliRunner()
         result = runner.invoke(cli, ["profile", "show", "myp2"])
         assert result.exit_code == 0, result.output
@@ -2760,7 +2768,7 @@ class TestProfileShowSingularFlags:
     def test_other_keys_still_hyphenated(self, tmp_config):
         """profile show still hyphenates other underscore keys correctly."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_profiles({"myp3": {"min_rating": 4.0, "first_in_series": True}})
+        cli_mod.save_profiles({"myp3": {"min_rating": 4.0, "first_in_series": True}})
         runner = CliRunner()
         result = runner.invoke(cli, ["profile", "show", "myp3"])
         assert result.exit_code == 0, result.output
@@ -3128,31 +3136,31 @@ class TestConfigResetConfirmation:
     def test_reset_all_confirmed(self, tmp_config):
         """config reset with no key clears config when user confirms."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_config({"max_price": 5.0, "min_rating": 4.0})
+        cli_mod.save_config({"max_price": 5.0, "min_rating": 4.0})
         runner = CliRunner()
         result = runner.invoke(cli, ["config", "reset"], input="y\n")
         assert result.exit_code == 0, result.output
         assert "All global defaults cleared" in result.output
-        assert cli_mod._load_config() == {}
+        assert cli_mod.load_config() == {}
 
     def test_reset_all_cancelled(self, tmp_config):
         """config reset with no key leaves config intact when user cancels."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_config({"max_price": 5.0})
+        cli_mod.save_config({"max_price": 5.0})
         runner = CliRunner()
         result = runner.invoke(cli, ["config", "reset"], input="n\n")
         assert result.exit_code == 0, result.output
         assert "Cancelled" in result.output
-        assert cli_mod._load_config() == {"max_price": 5.0}
+        assert cli_mod.load_config() == {"max_price": 5.0}
 
     def test_reset_key_no_confirmation_needed(self, tmp_config):
         """config reset KEY skips the confirmation prompt."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_config({"max_price": 5.0, "min_rating": 4.0})
+        cli_mod.save_config({"max_price": 5.0, "min_rating": 4.0})
         runner = CliRunner()
         result = runner.invoke(cli, ["config", "reset", "max-price"])
         assert result.exit_code == 0, result.output
-        cfg = cli_mod._load_config()
+        cfg = cli_mod.load_config()
         assert "max_price" not in cfg
         assert "min_rating" in cfg
 
@@ -3194,7 +3202,7 @@ class TestWishlistRemoveLast:
         import audible_deals.cli as cli_mod
         p = make_product(asin="WRL1", title="Remove Me")
         self._seed_cache(tmp_config, [p])
-        cli_mod._save_wishlist([{"asin": "WRL1", "title": "Remove Me", "max_price": None, "added": ""}])
+        cli_mod.save_wishlist([{"asin": "WRL1", "title": "Remove Me", "max_price": None, "added": ""}])
 
         runner = CliRunner()
         result = runner.invoke(cli, ["wishlist", "remove", "--last", "1"])
@@ -3207,7 +3215,7 @@ class TestWishlistRemoveLast:
         import audible_deals.cli as cli_mod
         p = make_product(asin="WRL2", title="Cache Book")
         self._seed_cache(tmp_config, [p])
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "WRL2", "title": "Cache Book", "max_price": None, "added": ""},
             {"asin": "WRL3", "title": "Direct Book", "max_price": None, "added": ""},
         ])
@@ -3234,7 +3242,7 @@ class TestHistoryLast:
     def test_history_last_resolves_from_cache(self, tmp_config):
         """history --last N resolves the ASIN from the last results cache."""
         import audible_deals.cli as cli_mod
-        from audible_deals.cli import _record_prices
+        from audible_deals.state import record_prices as _record_prices
         p = make_product(asin="HL1", price=4.99, title="Cache History Book")
         self._seed_cache(tmp_config, [p])
         _record_prices([p])
@@ -3443,7 +3451,7 @@ class TestProfileSaveFalsy:
         runner = CliRunner()
         result = runner.invoke(cli, ["profile", "save", "zeroprofile", "--max-price", "0"])
         assert result.exit_code == 0, result.output
-        profiles = cli_mod._load_profiles()
+        profiles = cli_mod.load_profiles()
         assert "max_price" in profiles["zeroprofile"]
         assert profiles["zeroprofile"]["max_price"] == 0.0
 
@@ -3454,7 +3462,7 @@ class TestProfileSaveFalsy:
         runner = CliRunner()
         result = runner.invoke(cli, ["profile", "save", "falseprofile", "--genre", "sci-fi"])
         assert result.exit_code == 0, result.output
-        profiles = cli_mod._load_profiles()
+        profiles = cli_mod.load_profiles()
         # on_sale=False is NOT stored — profile save's is_flag options only capture True
         assert "on_sale" not in profiles["falseprofile"]
 
@@ -3465,7 +3473,7 @@ class TestProfileSaveFalsy:
         runner = CliRunner()
         result = runner.invoke(cli, ["profile", "save", "emptyprofile", "--max-price", "0"])
         assert result.exit_code == 0, result.output
-        profiles = cli_mod._load_profiles()
+        profiles = cli_mod.load_profiles()
         # Empty string fields like genre, author etc. should not be saved
         assert "genre" not in profiles["emptyprofile"]
         assert "author" not in profiles["emptyprofile"]
@@ -3477,7 +3485,7 @@ class TestProfileSaveFalsy:
 class TestProfileSaveZeroDefaults:
     def test_profile_save_omits_zero_defaults(self, tmp_config):
         """profile save --genre sci-fi must NOT save min_rating=0.0 etc."""
-        from audible_deals.state import _load_profiles
+        from audible_deals.state import load_profiles as _load_profiles
         runner = CliRunner()
         result = runner.invoke(cli, ["profile", "save", "zerotest", "--genre", "sci-fi"])
         assert result.exit_code == 0, result.output
@@ -3490,7 +3498,7 @@ class TestProfileSaveZeroDefaults:
 
     def test_profile_save_preserves_explicit_zero(self, tmp_config):
         """profile save --max-price 0 must keep max_price=0.0."""
-        from audible_deals.state import _load_profiles
+        from audible_deals.state import load_profiles as _load_profiles
         runner = CliRunner()
         result = runner.invoke(cli, ["profile", "save", "zeroexplicit", "--max-price", "0"])
         assert result.exit_code == 0, result.output
@@ -3507,7 +3515,7 @@ class TestNotifyEmpty:
         """notify with wishlist items above target prints '[]' to stdout."""
         import audible_deals.cli as cli_mod
         # Add a wishlist item with a low target (price above target = no hit)
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "NE01", "title": "Pricey Book", "max_price": 1.0, "added": "2024-01-01"},
         ])
         # Mock get_products_batch to return product with price above target
@@ -3522,14 +3530,14 @@ class TestNotifyEmpty:
     def test_notify_no_hits_with_webhook_shows_feedback(self, mock_client, tmp_config, monkeypatch):
         """notify with no hits and a webhook prints feedback but does not POST."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "NE02", "title": "Pricey Book", "max_price": 1.0, "added": "2024-01-01"},
         ])
         mock_client.get_products_batch.return_value = [
             make_product(asin="NE02", price=9.99),
         ]
         # Use a valid-looking but unreachable webhook; should never be called
-        monkeypatch.setattr("audible_deals.cli._validate_webhook_url", lambda url: None)
+        monkeypatch.setattr("audible_deals.cli.validate_webhook_url", lambda url: None)
         runner = CliRunner()
         result = runner.invoke(cli, ["notify", "--webhook", "https://example.com/hook"])
         assert result.exit_code == 0, result.output
@@ -3546,7 +3554,7 @@ class TestNotifyZeroTarget:
     def test_notify_zero_target_fires(self, mock_client, tmp_config):
         """notify must fire when max_price=0 and product price is 0 (was falsy bug)."""
         import audible_deals.cli as cli_mod
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "Z001", "title": "Free Book", "max_price": 0, "added": "2024-01-01"},
         ])
         mock_client.get_products_batch.return_value = [
@@ -3563,7 +3571,7 @@ class TestNotifyZeroTarget:
 class TestProfileSaveNewOptions:
     def test_profile_save_min_discount(self, tmp_config):
         """profile save --min-discount should persist."""
-        from audible_deals.state import _load_profiles
+        from audible_deals.state import load_profiles as _load_profiles
         runner = CliRunner()
         result = runner.invoke(cli, ["profile", "save", "disctest", "--min-discount", "50"])
         assert result.exit_code == 0, result.output
@@ -3572,7 +3580,7 @@ class TestProfileSaveNewOptions:
 
     def test_profile_save_max_pph(self, tmp_config):
         """profile save --max-price-per-hour should persist."""
-        from audible_deals.state import _load_profiles
+        from audible_deals.state import load_profiles as _load_profiles
         runner = CliRunner()
         result = runner.invoke(cli, ["profile", "save", "pphtest", "--max-price-per-hour", "0.5"])
         assert result.exit_code == 0, result.output
@@ -3581,7 +3589,7 @@ class TestProfileSaveNewOptions:
 
     def test_profile_save_publisher(self, tmp_config):
         """profile save --publisher should persist."""
-        from audible_deals.state import _load_profiles
+        from audible_deals.state import load_profiles as _load_profiles
         runner = CliRunner()
         result = runner.invoke(cli, ["profile", "save", "pubtest", "--publisher", "Penguin"])
         assert result.exit_code == 0, result.output
@@ -3648,7 +3656,7 @@ class TestLastCount:
     def _write_cache(self, tmp_config, products):
         """Write a mock last results cache."""
         import audible_deals.cli as cli_mod
-        data = [cli_mod._serialize_product(p) for p in products]
+        data = [cli_mod.serialize_product(p) for p in products]
         payload = json.dumps({"title": "Test Results", "results": data})
         cli_mod.LAST_RESULTS_FILE.write_text(payload)
 
@@ -3938,9 +3946,9 @@ class TestWatchRecordsPrices:
     def test_watch_records_prices(self, mock_client, tmp_config):
         """After running watch, history should contain an entry for the watched ASIN."""
         import audible_deals.cli as cli_mod
-        from audible_deals.state import _load_price_history
+        from audible_deals.state import load_price_history as _load_price_history
 
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "WR1", "title": "Record Me", "max_price": 10.0, "added": ""},
         ])
         mock_client.get_products_batch.return_value = [
@@ -3962,9 +3970,9 @@ class TestNotifyRecordsPrices:
     def test_notify_records_prices(self, mock_client, tmp_config):
         """notify records prices for fetched items."""
         import audible_deals.cli as cli_mod
-        from audible_deals.state import _load_price_history
+        from audible_deals.state import load_price_history as _load_price_history
 
-        cli_mod._save_wishlist([
+        cli_mod.save_wishlist([
             {"asin": "NR1", "title": "Deal Book", "max_price": 5.0, "added": ""},
         ])
         mock_client.get_products_batch.return_value = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1488,70 +1488,69 @@ class TestConfigBooleanOverride:
     def test_config_bool_not_overridden_when_cli_explicit(self):
         """Config booleans must not override when the user explicitly passed the flag."""
         from unittest.mock import MagicMock
-        from audible_deals.cli import _apply_config_defaults, _CL
+        from audible_deals.cli import _CL
+        from audible_deals.settings import Settings
 
         ctx = MagicMock()
         ctx.get_parameter_source.return_value = _CL  # Simulate CLI explicit
-        ns = {"on_sale": False, "deep": False}
-        cfg = {"on_sale": True, "deep": True}
-        _apply_config_defaults(ctx, ns, cfg)
-        assert ns["on_sale"] is False
-        assert ns["deep"] is False
+        s = Settings.resolve(ctx, config={"on_sale": True, "deep": True},
+                             profile=None, cli_flags={"on_sale": False, "deep": False})
+        assert s.on_sale is False
+        assert s.deep is False
 
     def test_config_bool_applied_when_not_cli(self):
         """Config booleans should apply when user did NOT pass the flag."""
         from unittest.mock import MagicMock
         import click
-        from audible_deals.cli import _apply_config_defaults
+        from audible_deals.settings import Settings
 
         ctx = MagicMock()
         ctx.get_parameter_source.return_value = click.core.ParameterSource.DEFAULT
-        ns = {"on_sale": False, "deep": False}
-        cfg = {"on_sale": True, "deep": True}
-        _apply_config_defaults(ctx, ns, cfg)
-        assert ns["on_sale"] is True
-        assert ns["deep"] is True
+        s = Settings.resolve(ctx, config={"on_sale": True, "deep": True},
+                             profile=None, cli_flags={"on_sale": False, "deep": False})
+        assert s.on_sale is True
+        assert s.deep is True
 
     def test_config_bool_false_applied_when_not_cli(self):
         """Config with explicit False should set ns to False when source is DEFAULT."""
         from unittest.mock import MagicMock
         import click
-        from audible_deals.cli import _apply_config_defaults
+        from audible_deals.settings import Settings
 
         ctx = MagicMock()
         ctx.get_parameter_source.return_value = click.core.ParameterSource.DEFAULT
-        ns = {"on_sale": True, "deep": True}
-        cfg = {"on_sale": False, "deep": False}
-        _apply_config_defaults(ctx, ns, cfg)
-        assert ns["on_sale"] is False
-        assert ns["deep"] is False
+        s = Settings.resolve(ctx, config={"on_sale": False, "deep": False},
+                             profile=None, cli_flags={"on_sale": True, "deep": True})
+        assert s.on_sale is False
+        assert s.deep is False
 
     def test_profile_bool_not_overridden_when_cli_explicit(self):
         """Profile booleans must not override when the user explicitly passed the flag."""
         from unittest.mock import MagicMock
-        from audible_deals.cli import _apply_profile_defaults, _CL
+        from audible_deals.cli import _CL
+        from audible_deals.settings import Settings
 
         ctx = MagicMock()
         ctx.get_parameter_source.return_value = _CL
-        ns = {"on_sale": False, "deep": False}
-        profile = {"on_sale": True, "deep": True}
-        _apply_profile_defaults(ctx, ns, profile)
-        assert ns["on_sale"] is False
-        assert ns["deep"] is False
+        s = Settings.resolve(ctx, config={},
+                             profile={"on_sale": True, "deep": True},
+                             cli_flags={"on_sale": False, "deep": False})
+        assert s.on_sale is False
+        assert s.deep is False
 
     def test_profile_bool_applied_when_not_cli(self):
         """Profile booleans should apply when user did NOT pass the flag."""
         from unittest.mock import MagicMock
         import click
-        from audible_deals.cli import _apply_profile_defaults
+        from audible_deals.settings import Settings
 
         ctx = MagicMock()
         ctx.get_parameter_source.return_value = click.core.ParameterSource.DEFAULT
-        ns = {"on_sale": False, "deep": False}
-        profile = {"on_sale": True, "deep": True}
-        _apply_profile_defaults(ctx, ns, profile)
-        assert ns["on_sale"] is True
-        assert ns["deep"] is True
+        s = Settings.resolve(ctx, config={},
+                             profile={"on_sale": True, "deep": True},
+                             cli_flags={"on_sale": False, "deep": False})
+        assert s.on_sale is True
+        assert s.deep is True
 
 
 # ===================================================================
@@ -3868,68 +3867,65 @@ class TestStringKeyPrecedence:
         """When config set a string, profile must override it."""
         from unittest.mock import MagicMock
         import click
-        from audible_deals.cli import _apply_config_defaults, _apply_profile_defaults
+        from audible_deals.settings import Settings
 
         ctx = MagicMock()
         ctx.get_parameter_source.return_value = click.core.ParameterSource.DEFAULT
-        ns = {"language": "", "narrator": "", "author": "", "series": "", "publisher": ""}
         cfg = {"language": "english", "narrator": "Alice"}
         profile = {"language": "french", "narrator": "Bob"}
+        cli_flags = {"language": "", "narrator": "", "author": "", "series": "", "publisher": ""}
 
-        _apply_config_defaults(ctx, ns, cfg)
-        assert ns["language"] == "english"
-        assert ns["narrator"] == "Alice"
+        s = Settings.resolve(ctx, config=cfg, profile=None, cli_flags=cli_flags)
+        assert s.language == "english"
+        assert s.narrator == "Alice"
 
-        _apply_profile_defaults(ctx, ns, profile)
-        assert ns["language"] == "french"
-        assert ns["narrator"] == "Bob"
+        s2 = Settings.resolve(ctx, config=cfg, profile=profile, cli_flags=cli_flags)
+        assert s2.language == "french"
+        assert s2.narrator == "Bob"
 
     def test_config_string_applied_when_no_profile(self):
         """Config string fills ns when CLI absent and no profile override."""
         from unittest.mock import MagicMock
         import click
-        from audible_deals.cli import _apply_config_defaults
+        from audible_deals.settings import Settings
 
         ctx = MagicMock()
         ctx.get_parameter_source.return_value = click.core.ParameterSource.DEFAULT
-        ns = {"language": "", "narrator": ""}
         cfg = {"language": "french", "narrator": "Alice"}
-        _apply_config_defaults(ctx, ns, cfg)
-        assert ns["language"] == "french"
-        assert ns["narrator"] == "Alice"
+        s = Settings.resolve(ctx, config=cfg, profile=None,
+                             cli_flags={"language": "", "narrator": ""})
+        assert s.language == "french"
+        assert s.narrator == "Alice"
 
     def test_cli_string_overrides_both(self):
         """CLI-supplied string must not be overridden by config or profile."""
         from unittest.mock import MagicMock
-        from audible_deals.cli import _apply_config_defaults, _apply_profile_defaults, _CL
+        from audible_deals.cli import _CL
+        from audible_deals.settings import Settings
 
         ctx = MagicMock()
         ctx.get_parameter_source.return_value = _CL
-        ns = {"language": "spanish", "narrator": "Carlos"}
         cfg = {"language": "english", "narrator": "Alice"}
         profile = {"language": "french", "narrator": "Bob"}
+        cli_flags = {"language": "spanish", "narrator": "Carlos"}
 
-        _apply_config_defaults(ctx, ns, cfg)
-        assert ns["language"] == "spanish"
-        assert ns["narrator"] == "Carlos"
-
-        _apply_profile_defaults(ctx, ns, profile)
-        assert ns["language"] == "spanish"
-        assert ns["narrator"] == "Carlos"
+        s = Settings.resolve(ctx, config=cfg, profile=profile, cli_flags=cli_flags)
+        assert s.language == "spanish"
+        assert s.narrator == "Carlos"
 
     def test_profile_only_keys_applied(self):
         """Profile-only string keys (genre, keywords) are applied when CLI absent."""
         from unittest.mock import MagicMock
         import click
-        from audible_deals.cli import _apply_profile_defaults
+        from audible_deals.settings import Settings
 
         ctx = MagicMock()
         ctx.get_parameter_source.return_value = click.core.ParameterSource.DEFAULT
-        ns = {"genre": "", "keywords": "", "exclude_genre": (), "exclude_authors": ()}
         profile = {"genre": "mystery", "keywords": "thriller"}
-        _apply_profile_defaults(ctx, ns, profile)
-        assert ns["genre"] == "mystery"
-        assert ns["keywords"] == "thriller"
+        cli_flags = {"genre": "", "keywords": "", "exclude_genre": (), "exclude_authors": ()}
+        s = Settings.resolve(ctx, config={}, profile=profile, cli_flags=cli_flags)
+        assert s.genre == "mystery"
+        assert s.keywords == "thriller"
 
 
 # ===================================================================

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,0 +1,346 @@
+"""Tests for audible_deals.filtering — pure product filtering, sorting, deduplication."""
+
+from __future__ import annotations
+
+import pytest
+
+from audible_deals.filtering import (
+    dedupe_editions,
+    filter_products,
+    first_in_series,
+    price_per_hour,
+    sort_local,
+    value_score,
+)
+from audible_deals.client import Product
+from tests.conftest import make_product
+
+
+# ===================================================================
+# filter_products
+# ===================================================================
+
+class TestFilterProducts:
+    def test_max_price(self, products_for_filtering):
+        filtered, breakdown = filter_products(products_for_filtering, max_price=5.0)
+        assert all(p.price is not None and p.price <= 5.0 for p in filtered)
+        assert breakdown.get("max price", 0) > 0
+
+    def test_min_rating(self, products_for_filtering):
+        filtered, _ = filter_products(products_for_filtering, min_rating=4.0)
+        assert all(p.rating >= 4.0 for p in filtered)
+
+    def test_min_hours(self, products_for_filtering):
+        filtered, _ = filter_products(products_for_filtering, min_hours=5.0)
+        assert all(p.hours >= 5.0 for p in filtered)
+
+    def test_language(self, products_for_filtering):
+        filtered, _ = filter_products(products_for_filtering, language="french")
+        assert all(p.language.lower() == "french" for p in filtered)
+        assert len(filtered) == 1
+
+    def test_on_sale(self, products_for_filtering):
+        filtered, _ = filter_products(products_for_filtering, on_sale=True)
+        assert all(p.discount_pct is not None and p.discount_pct > 0 for p in filtered)
+        assert not any(p.asin in ("NO_PRICE", "EXPENSIVE") for p in filtered)
+
+    def test_skip_asins(self, products_for_filtering):
+        filtered, _ = filter_products(products_for_filtering, skip_asins={"CHEAP1", "CHEAP2"})
+        assert not any(p.asin in {"CHEAP1", "CHEAP2"} for p in filtered)
+
+    def test_exclude_category_ids(self, products_for_filtering):
+        filtered, _ = filter_products(
+            products_for_filtering, exclude_category_ids={"cat_erotica"}
+        )
+        assert not any(p.asin == "EROTICA" for p in filtered)
+
+    def test_no_filters(self, products_for_filtering):
+        filtered, breakdown = filter_products(products_for_filtering)
+        assert len(filtered) == len(products_for_filtering)
+        assert breakdown == {}
+
+    def test_combined_filters(self, products_for_filtering):
+        filtered, _ = filter_products(
+            products_for_filtering,
+            max_price=5.0, min_rating=4.0, language="english",
+        )
+        for p in filtered:
+            assert p.price is not None and p.price <= 5.0
+            assert p.rating >= 4.0
+            assert p.language.lower() == "english"
+
+
+# ===================================================================
+# price_per_hour
+# ===================================================================
+
+class TestPricePerHour:
+    def test_normal(self):
+        p = make_product(price=10.0, length_minutes=600)
+        assert price_per_hour(p) == pytest.approx(1.0)
+
+    def test_no_price(self):
+        p = make_product(price=None)
+        assert price_per_hour(p) == float("inf")
+
+    def test_zero_hours(self):
+        p = make_product(price=5.0, length_minutes=0)
+        assert price_per_hour(p) == float("inf")
+
+
+# ===================================================================
+# sort_local
+# ===================================================================
+
+class TestSortLocal:
+    @pytest.fixture
+    def products(self):
+        return [
+            make_product(asin="A", price=5.0, rating=3.0, length_minutes=300,
+                         release_date="2024-01-01", list_price=10.0),
+            make_product(asin="B", price=2.0, rating=5.0, length_minutes=600,
+                         release_date="2024-06-01", list_price=20.0),
+            make_product(asin="C", price=8.0, rating=4.0, length_minutes=120,
+                         release_date="2023-01-01", list_price=10.0),
+        ]
+
+    def test_sort_price(self, products):
+        result = sort_local(products, "price")
+        prices = [p.price for p in result]
+        assert prices == sorted(prices)
+
+    def test_sort_price_reverse(self, products):
+        result = sort_local(products, "-price")
+        prices = [p.price for p in result]
+        assert prices == sorted(prices, reverse=True)
+
+    def test_sort_rating(self, products):
+        result = sort_local(products, "rating")
+        ratings = [p.rating for p in result]
+        assert ratings == sorted(ratings, reverse=True)
+
+    def test_sort_length(self, products):
+        result = sort_local(products, "length")
+        lengths = [p.length_minutes for p in result]
+        assert lengths == sorted(lengths, reverse=True)
+
+    def test_sort_date(self, products):
+        result = sort_local(products, "date")
+        dates = [p.release_date for p in result]
+        assert dates == sorted(dates, reverse=True)
+
+    def test_sort_discount(self, products):
+        result = sort_local(products, "discount")
+        discounts = [p.discount_pct or 0 for p in result]
+        assert discounts == sorted(discounts, reverse=True)
+
+    def test_sort_price_per_hour(self, products):
+        result = sort_local(products, "price-per-hour")
+        pphs = [price_per_hour(p) for p in result]
+        assert pphs == sorted(pphs)
+
+    def test_sort_unknown_passthrough(self, products):
+        result = sort_local(products, "relevance")
+        assert [p.asin for p in result] == ["A", "B", "C"]
+
+    def test_sort_price_with_none(self):
+        products = [
+            make_product(asin="X", price=None),
+            make_product(asin="Y", price=3.0),
+        ]
+        result = sort_local(products, "price")
+        assert result[0].asin == "Y"
+        assert result[1].asin == "X"
+
+
+# ===================================================================
+# dedupe_editions
+# ===================================================================
+
+class TestDedupeEditions:
+    def test_keeps_cheapest(self):
+        products = [
+            make_product(asin="A", series_name="S", series_position="1", price=10.0),
+            make_product(asin="B", series_name="S", series_position="1", price=5.0),
+        ]
+        result, removed = dedupe_editions(products)
+        assert removed == 1
+        assert len(result) == 1
+        assert result[0].asin == "B"
+
+    def test_no_series_pass_through(self):
+        products = [
+            make_product(asin="A", series_name="", series_position=""),
+            make_product(asin="B", series_name="", series_position=""),
+        ]
+        result, removed = dedupe_editions(products)
+        assert removed == 0
+        assert len(result) == 2
+
+    def test_different_positions_kept(self):
+        products = [
+            make_product(asin="A", series_name="S", series_position="1", price=5.0),
+            make_product(asin="B", series_name="S", series_position="2", price=5.0),
+        ]
+        result, removed = dedupe_editions(products)
+        assert removed == 0
+        assert len(result) == 2
+
+    def test_case_insensitive(self):
+        products = [
+            make_product(asin="A", series_name="Epic", series_position="1", price=10.0),
+            make_product(asin="B", series_name="epic", series_position="1", price=5.0),
+        ]
+        result, removed = dedupe_editions(products)
+        assert removed == 1
+
+
+# ===================================================================
+# first_in_series
+# ===================================================================
+
+class TestFirstInSeries:
+    def test_keeps_lowest_position(self):
+        products = [
+            make_product(asin="A", series_name="S", series_position="3"),
+            make_product(asin="B", series_name="S", series_position="1"),
+            make_product(asin="C", series_name="S", series_position="2"),
+        ]
+        result, collapsed = first_in_series(products)
+        assert collapsed == 2
+        assert len(result) == 1
+        assert result[0].asin == "B"
+
+    def test_non_series_pass_through(self):
+        products = [
+            make_product(asin="A", series_name=""),
+            make_product(asin="B", series_name=""),
+        ]
+        result, collapsed = first_in_series(products)
+        assert collapsed == 0
+        assert len(result) == 2
+
+    def test_different_series(self):
+        products = [
+            make_product(asin="A", series_name="S1", series_position="2"),
+            make_product(asin="B", series_name="S2", series_position="3"),
+        ]
+        result, collapsed = first_in_series(products)
+        assert collapsed == 2
+        assert len(result) == 0
+
+    def test_different_series_with_book1(self):
+        products = [
+            make_product(asin="A", series_name="S1", series_position="1"),
+            make_product(asin="B", series_name="S2", series_position="1"),
+        ]
+        result, collapsed = first_in_series(products)
+        assert collapsed == 0
+        assert len(result) == 2
+
+    def test_non_numeric_position(self):
+        products = [
+            make_product(asin="A", series_name="S", series_position="Book 1"),
+            make_product(asin="B", series_name="S", series_position="1"),
+        ]
+        result, collapsed = first_in_series(products)
+        assert collapsed == 1
+        assert result[0].asin == "B"
+
+
+class TestFirstInSeriesStrict:
+    def test_book3_only_gets_filtered_out(self):
+        products = [
+            make_product(asin="FIS1", series_name="Epic Series", series_position="3"),
+        ]
+        result, collapsed = first_in_series(products)
+        assert collapsed == 1
+        assert len(result) == 0
+
+    def test_prequel_at_half_passes(self):
+        products = [
+            make_product(asin="FIS2", series_name="Epic Series", series_position="0.5"),
+        ]
+        result, collapsed = first_in_series(products)
+        assert collapsed == 0
+        assert len(result) == 1
+        assert result[0].asin == "FIS2"
+
+    def test_position_one_point_zero_passes(self):
+        products = [
+            make_product(asin="FIS3", series_name="Epic Series", series_position="1.0"),
+        ]
+        result, collapsed = first_in_series(products)
+        assert collapsed == 0
+        assert len(result) == 1
+        assert result[0].asin == "FIS3"
+
+    def test_book1_in_series_passes(self):
+        products = [
+            make_product(asin="FIS4", series_name="A Series", series_position="1"),
+            make_product(asin="FIS5", series_name="A Series", series_position="2"),
+        ]
+        result, collapsed = first_in_series(products)
+        assert collapsed == 1
+        assert result[0].asin == "FIS4"
+
+    def test_non_series_pass_through_unchanged(self):
+        products = [
+            make_product(asin="FIS6", series_name=""),
+            make_product(asin="FIS7", series_name=""),
+        ]
+        result, collapsed = first_in_series(products)
+        assert collapsed == 0
+        assert len(result) == 2
+
+    def test_mixed_book1_and_no_book1(self):
+        products = [
+            make_product(asin="FIS8", series_name="HasBook1", series_position="1"),
+            make_product(asin="FIS9", series_name="NoBook1", series_position="3"),
+        ]
+        result, collapsed = first_in_series(products)
+        asins = [p.asin for p in result]
+        assert "FIS8" in asins
+        assert "FIS9" not in asins
+        assert collapsed == 1
+
+
+# ===================================================================
+# filter_products — series filter
+# ===================================================================
+
+class TestFilterSeries:
+    def test_filter_series_match(self):
+        products = [
+            make_product(asin="S1", series_name="The Stormlight Archive"),
+            make_product(asin="S2", series_name="Mistborn"),
+            make_product(asin="S3", series_name="Stormlight Chronicles"),
+        ]
+        filtered, breakdown = filter_products(products, series="stormlight")
+        assert len(filtered) == 2
+        assert all(p.asin in ("S1", "S3") for p in filtered)
+
+    def test_filter_series_no_match(self):
+        products = [
+            make_product(asin="S1", series_name="Mistborn"),
+            make_product(asin="S2", series_name="The Way of Kings"),
+        ]
+        filtered, breakdown = filter_products(products, series="wheel of time")
+        assert len(filtered) == 0
+        assert breakdown.get("series") == 2
+
+    def test_filter_series_case_insensitive(self):
+        products = [
+            make_product(asin="S1", series_name="The Dresden Files"),
+        ]
+        filtered, _ = filter_products(products, series="DRESDEN")
+        assert len(filtered) == 1
+
+    def test_filter_series_empty_no_filter(self):
+        products = [
+            make_product(asin="S1", series_name="Mistborn"),
+            make_product(asin="S2", series_name=""),
+        ]
+        filtered, breakdown = filter_products(products, series="")
+        assert len(filtered) == 2
+        assert "series" not in breakdown

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,7 +16,9 @@ import pytest
 from click.testing import CliRunner
 
 from audible_deals.client import DealsClient, MAX_PAGE_SIZE
-from audible_deals.cli import _export_products, _record_prices, cli
+from audible_deals.cli import cli
+from audible_deals.serialization import export_products as _export_products
+from audible_deals.state import record_prices as _record_prices
 from tests.conftest import make_product, make_raw
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,71 @@
+"""Tests for audible_deals.state — persistence and I/O functions."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from audible_deals.cli import cli
+from audible_deals.state import load_seen_asins, save_seen_asins
+from tests.conftest import make_product
+
+
+# ===================================================================
+# load_seen_asins / save_seen_asins
+# ===================================================================
+
+class TestLoadSeenAsins:
+    def test_loads_from_seen_file(self, tmp_config):
+        import audible_deals.state as state_mod
+        state_mod.SEEN_ASINS_FILE.write_text(json.dumps(["A1", "A2"]))
+        seen = load_seen_asins()
+        assert seen == {"A1", "A2"}
+
+    def test_empty_when_no_file(self, tmp_config):
+        seen = load_seen_asins()
+        assert seen == set()
+
+    def test_returns_set_from_list(self, tmp_config):
+        import audible_deals.state as state_mod
+        state_mod.SEEN_ASINS_FILE.write_text(json.dumps(["B1", "B2", "B1"]))
+        seen = load_seen_asins()
+        assert seen == {"B1", "B2"}
+
+    def test_empty_on_corrupt_file(self, tmp_config):
+        import audible_deals.state as state_mod
+        state_mod.SEEN_ASINS_FILE.write_text("not valid json")
+        seen = load_seen_asins()
+        assert seen == set()
+
+
+class TestCumulativeSeenAsins:
+    def test_save_and_load(self, tmp_config):
+        save_seen_asins({"A1", "A2"})
+        assert load_seen_asins() == {"A1", "A2"}
+
+    def test_cumulative_append(self, tmp_config):
+        save_seen_asins({"A1", "A2"})
+        save_seen_asins({"A3", "A4"})
+        assert load_seen_asins() == {"A1", "A2", "A3", "A4"}
+
+    def test_no_duplicates(self, tmp_config):
+        import audible_deals.state as state_mod
+        save_seen_asins({"A1", "A2"})
+        save_seen_asins({"A2", "A3"})
+        seen = load_seen_asins()
+        assert seen == {"A1", "A2", "A3"}
+        data = json.loads(state_mod.SEEN_ASINS_FILE.read_text())
+        assert data == sorted(data)
+
+    def test_empty_when_no_file(self, tmp_config):
+        assert load_seen_asins() == set()
+
+    def test_clear_seen_command(self, tmp_config, mock_client):
+        save_seen_asins({"A1", "A2"})
+        runner = CliRunner()
+        result = runner.invoke(cli, ["last", "--clear-seen"])
+        assert result.exit_code == 0
+        assert "cleared" in result.output.lower()
+        assert load_seen_asins() == set()


### PR DESCRIPTION
## Summary

Internal refactor of the CLI. No behavior change, no new dependencies, no new directory layers.

- **Settings dataclass** — replaces `_apply_config_defaults` / `_apply_profile_defaults` with a single `Settings.resolve()` that merges `defaults ← config ← profile ← cli_flags` in one pass. Closes the bug class behind recent fix commits.
- **Pure functions moved to `filtering.py`** — `filter_products`, `dedupe_editions`, `first_in_series`, `sort_local`, etc. out of `cli.py`. `state.py` API made public. The 171 KB `test_cli.py` split into `test_filtering.py` + `test_state.py` + a smaller `test_cli.py` (CliRunner integration only).
- **`_postprocess_and_output` decomposed** into three helpers (`_apply_filters`, `_record_and_cache`, `_emit_output`) called directly per command.
- **Post-review cleanup** — kill `_resolve_scan_settings` adapter, drop import-alias band-aids, introduce `DEFAULT_LIMIT` / `DEFAULT_SORT` constants.

Architectural choices vetted by independent reviewers — explicitly skipped: directory split, `Pipeline` class, `Store` ABC, Pydantic, `AppContext` wrapper.

## Test plan

- [x] `pytest -q`: 619 passed (2 pre-existing failures unchanged — `tmp_config` fixture patches the wrong module name)
- [x] CLI smoke in isolated `$HOME`: all 17 subcommands load; `config` / `profile` / `wishlist` / `last` CRUD verified; Settings precedence checked at each of the four layers

## Follow-ups (pre-existing, not in this PR)

- `tmp_config` fixture: patch `cli_mod.WISHLIST_FILE` / `cli_mod.PROFILES_FILE`
- `series` command silently ignores `--profile`
- `deals completions {bash,zsh,fish}` prints help instead of a completion script

🤖 Generated with [Claude Code](https://claude.com/claude-code)