### PR TITLE
fix: resolve Unicode encoding errors on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+- Windows: CLI crashed with `UnicodeEncodeError` when the console used a legacy code page (e.g. cp1252) and could not encode the Unicode glyphs Rich renders. The standard streams are now reconfigured to UTF-8 at startup.
+
 ## [0.9.0] - 2026-06-22
 
 ### Added

--- a/src/audible_deals/cli/__init__.py
+++ b/src/audible_deals/cli/__init__.py
@@ -21,6 +21,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import sys
 
 try:
     import readline  # noqa: F401 — required on macOS for input() with long strings
@@ -43,6 +44,26 @@ from audible_deals.display import console
 from audible_deals.logging_setup import configure_logging
 
 logger = logging.getLogger(__name__)
+
+
+def _force_utf8_output() -> None:
+    """Reconfigure the standard streams to UTF-8 on Windows.
+
+    Windows consoles often default to a legacy code page (e.g. cp1252) that
+    cannot encode the Unicode glyphs Rich renders, which otherwise crashes the
+    CLI with UnicodeEncodeError. reconfigure() mutates the existing stream in
+    place; guarded because captured/redirected/frozen streams may not support it.
+    """
+    if sys.platform != "win32":
+        return
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError):
+            pass
+
+
+_force_utf8_output()
 
 
 class _HandleAuthErrors(click.Group):

--- a/src/audible_deals/display.py
+++ b/src/audible_deals/display.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import collections
 import datetime
-import sys
 
 from rich.console import Console
 from rich.panel import Panel
@@ -23,12 +22,6 @@ from rich.table import Table
 
 from audible_deals.product import Product
 from audible_deals.metrics import buy_verdict, price_per_hour
-
-# On Windows, Rich has encoding issues with cp1252.
-# Force UTF-8 encoding by redirecting stdout if needed.
-if sys.platform == "win32" and sys.stdout.encoding != "utf-8":
-    import io
-    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
 console = Console()
 

--- a/src/audible_deals/display.py
+++ b/src/audible_deals/display.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import collections
 import datetime
+import sys
 
 from rich.console import Console
 from rich.panel import Panel
@@ -22,6 +23,12 @@ from rich.table import Table
 
 from audible_deals.product import Product
 from audible_deals.metrics import buy_verdict, price_per_hour
+
+# On Windows, Rich has encoding issues with cp1252.
+# Force UTF-8 encoding by redirecting stdout if needed.
+if sys.platform == "win32" and sys.stdout.encoding != "utf-8":
+    import io
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
 console = Console()
 

--- a/tests/test_utf8_output.py
+++ b/tests/test_utf8_output.py
@@ -1,0 +1,51 @@
+"""Tests for UTF-8 stream reconfiguration on Windows (_force_utf8_output)."""
+
+from __future__ import annotations
+
+import pytest
+
+from audible_deals.cli import _force_utf8_output
+
+
+class _FakeStream:
+    def __init__(self, raises=None):
+        self._raises = raises
+        self.calls = []
+
+    def reconfigure(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._raises is not None:
+            raise self._raises
+
+
+def test_reconfigures_both_streams_on_windows(monkeypatch):
+    out, err = _FakeStream(), _FakeStream()
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("sys.stdout", out)
+    monkeypatch.setattr("sys.stderr", err)
+
+    _force_utf8_output()
+
+    assert out.calls == [{"encoding": "utf-8", "errors": "replace"}]
+    assert err.calls == [{"encoding": "utf-8", "errors": "replace"}]
+
+
+def test_noop_off_windows(monkeypatch):
+    out = _FakeStream()
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setattr("sys.stdout", out)
+
+    _force_utf8_output()
+
+    assert out.calls == []
+
+
+@pytest.mark.parametrize("exc", [AttributeError, ValueError])
+def test_swallows_non_reconfigurable_streams(monkeypatch, exc):
+    out = _FakeStream(raises=exc())
+    err = _FakeStream(raises=exc())
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("sys.stdout", out)
+    monkeypatch.setattr("sys.stderr", err)
+
+    _force_utf8_output()  # must not raise


### PR DESCRIPTION
## Summary

Fix Critical Unicode encoding errors that prevented the CLI from running on Windows systems. Rich's Console was defaulting to cp1252 encoding, causing UnicodeEncodeError when rendering Unicode box-drawing characters (✓, ✗, ┃, etc.) used in tables and progress bars.

## Changes

- Added UTF-8 encoding override in `src/audible_deals/display.py`
- Wraps stdout with UTF-8 encoding on Windows if system default is not UTF-8
- Minimal change with no impact on other platforms

## Why This Matters

Windows terminals often use cp1252 (or other legacy encodings) by default, which cannot encode Unicode characters. This made the CLI completely non-functional on Windows—even basic commands like `deals doctor` would crash with UnicodeEncodeError.

## Testing

- ✅ CLI now works on Windows without PYTHONIOENCODING env var
- ✅ Tables render correctly with proper Unicode box characters
- ✅ All commands execute without encoding errors
- ✅ No impact on macOS/Linux behavior