### PR TITLE
Complete repository cleanup plan

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,10 +12,26 @@
 set -euo pipefail
 
 REPO="chauduyphanvu/audible-deals"
-INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
-LIB_DIR="${LIB_DIR:-$HOME/.local/lib/deals}"
+INSTALL_DIR="${INSTALL_DIR-$HOME/.local/bin}"
+LIB_DIR="${LIB_DIR-$HOME/.local/lib/deals}"
 BINARY_NAME="deals"
 FALLBACK_VERSION="0.9.1"
+INSTALL_MARKER_NAME=".audible-deals-install"
+INSTALL_MARKER_CONTENT="repository=chauduyphanvu/audible-deals"
+
+DOWNLOAD_DIR=""
+TRANSACTION_DIR=""
+BACKUP_MOVE_INTENT=0
+BACKUP_ACTIVE=0
+BACKUP_RESTORE_INTENT=0
+NEW_MOVE_INTENT=0
+NEW_ACTIVE=0
+NEW_ROLLBACK_INTENT=0
+LINK_CREATE_INTENT=0
+LINK_CREATED=0
+LIBRARY_STATE_AMBIGUOUS=0
+PRESERVE_TRANSACTION=0
+COMMITTED=0
 
 # --- Detect platform ---
 
@@ -94,10 +110,475 @@ sha256_file() {
     fi
 }
 
+# --- Path validation ---
+
+resolve_directory_path() {
+    local input="$1"
+    local physical component candidate result remainder
+    local -a pending
+    local pending_count=0
+    local index
+
+    if [ -z "$input" ]; then
+        echo "Error: directory path must not be empty." >&2
+        return 1
+    fi
+
+    if [[ "$input" = /* ]]; then
+        physical="/"
+    else
+        physical="$(pwd -P)" || return 1
+    fi
+
+    pending=()
+    remainder="$input/"
+
+    while [ -n "$remainder" ]; do
+        component="${remainder%%/*}"
+        remainder="${remainder#*/}"
+        case "$component" in
+            ""|.)
+                continue
+                ;;
+            ..)
+                if [ "$pending_count" -gt 0 ]; then
+                    index=$((pending_count - 1))
+                    unset "pending[$index]"
+                    pending_count=$index
+                else
+                    physical="$(cd -P -- "$physical/.." 2>/dev/null && pwd -P)" || {
+                        echo "Error: could not resolve directory path '$input'." >&2
+                        return 1
+                    }
+                fi
+                ;;
+            *)
+                if [ "$pending_count" -gt 0 ]; then
+                    pending[pending_count]="$component"
+                    pending_count=$((pending_count + 1))
+                    continue
+                fi
+
+                if [ "$physical" = "/" ]; then
+                    candidate="/$component"
+                else
+                    candidate="$physical/$component"
+                fi
+
+                if [ -d "$candidate" ]; then
+                    physical="$(cd -P -- "$candidate" 2>/dev/null && pwd -P)" || {
+                        echo "Error: could not resolve directory path '$input'." >&2
+                        return 1
+                    }
+                elif [ -e "$candidate" ] || [ -L "$candidate" ]; then
+                    echo "Error: path component '$candidate' is not a directory." >&2
+                    return 1
+                else
+                    pending[pending_count]="$component"
+                    pending_count=$((pending_count + 1))
+                fi
+                ;;
+        esac
+    done
+
+    result="$physical"
+    index=0
+    while [ "$index" -lt "$pending_count" ]; do
+        component="${pending[$index]}"
+        if [ "$result" = "/" ]; then
+            result="/$component"
+        else
+            result="$result/$component"
+        fi
+        index=$((index + 1))
+    done
+
+    echo "$result"
+}
+
+directory_is_empty() {
+    local directory="$1"
+    local entry
+
+    for entry in "$directory"/* "$directory"/.[!.]* "$directory"/..?*; do
+        if [ -e "$entry" ] || [ -L "$entry" ]; then
+            return 1
+        fi
+    done
+    return 0
+}
+
+path_exists() {
+    [ -e "$1" ] || [ -L "$1" ]
+}
+
+has_install_marker() {
+    local directory="$1"
+    local marker="$directory/$INSTALL_MARKER_NAME"
+    local marker_size
+
+    if [ ! -f "$marker" ] || [ -L "$marker" ]; then
+        return 1
+    fi
+
+    marker_size="$(wc -c < "$marker")" || return 1
+    [ "$marker_size" -eq "${#INSTALL_MARKER_CONTENT}" ] &&
+        [ "$(cat "$marker")" = "$INSTALL_MARKER_CONTENT" ]
+}
+
+validate_lib_dir() {
+    local input="${1-}"
+    local resolved canonical_home canonical_default parent
+
+    if [ -z "$input" ]; then
+        echo "Error: LIB_DIR must not be empty." >&2
+        return 1
+    fi
+    if [[ "$input" = *$'\n'* ]]; then
+        echo "Error: LIB_DIR must not contain newline characters." >&2
+        return 1
+    fi
+
+    resolved="$(resolve_directory_path "$input")" || return 1
+    canonical_home="$(resolve_directory_path "$HOME")" || {
+        echo "Error: HOME could not be resolved." >&2
+        return 1
+    }
+    canonical_default="$(resolve_directory_path "$HOME/.local/lib/deals")" || {
+        echo "Error: the default LIB_DIR could not be resolved." >&2
+        return 1
+    }
+
+    if [ "$resolved" = "/" ]; then
+        echo "Error: LIB_DIR must not be the filesystem root." >&2
+        return 1
+    fi
+
+    if [ "$resolved" = "$canonical_home" ] || [[ "$canonical_home" = "$resolved/"* ]]; then
+        echo "Error: LIB_DIR must not be HOME or an ancestor of HOME." >&2
+        return 1
+    fi
+
+    parent="${resolved%/*}"
+    if [ -z "$parent" ]; then
+        parent="/"
+    fi
+    if [ "$parent" = "/" ]; then
+        echo "Error: LIB_DIR must not be a one-component top-level path." >&2
+        return 1
+    fi
+
+    if [ -e "$resolved" ] && [ ! -d "$resolved" ]; then
+        echo "Error: LIB_DIR exists and is not a directory: $resolved" >&2
+        return 1
+    fi
+
+    if [ -d "$resolved" ] && ! directory_is_empty "$resolved"; then
+        if has_install_marker "$resolved"; then
+            :
+        elif [ "$resolved" = "$canonical_default" ] &&
+             [ -f "$resolved/$BINARY_NAME" ] &&
+             [ ! -L "$resolved/$BINARY_NAME" ]; then
+            :
+        else
+            echo "Error: existing LIB_DIR is not a dedicated audible-deals installation: $resolved" >&2
+            return 1
+        fi
+    fi
+
+    echo "$resolved"
+}
+
+validate_install_dir() {
+    local input="${1-}"
+    local lib_dir="$2"
+    local resolved link_path
+
+    if [ -z "$input" ]; then
+        echo "Error: INSTALL_DIR must not be empty." >&2
+        return 1
+    fi
+    if [[ "$input" = *$'\n'* ]]; then
+        echo "Error: INSTALL_DIR must not contain newline characters." >&2
+        return 1
+    fi
+
+    resolved="$(resolve_directory_path "$input")" || return 1
+    link_path="$resolved/$BINARY_NAME"
+
+    if [ "$link_path" = "$lib_dir" ] ||
+       [[ "$link_path" = "$lib_dir/"* ]] ||
+       [[ "$lib_dir" = "$link_path/"* ]]; then
+        echo "Error: INSTALL_DIR/$BINARY_NAME and LIB_DIR must not overlap." >&2
+        return 1
+    fi
+
+    if [ -d "$link_path" ]; then
+        echo "Error: a directory already exists at $link_path." >&2
+        return 1
+    fi
+
+    echo "$resolved"
+}
+
+command_link_is_managed() {
+    local link_path="$1/$BINARY_NAME"
+    local binary_path="$2/$BINARY_NAME"
+
+    [ -L "$link_path" ] && [ -e "$binary_path" ] && [ "$link_path" -ef "$binary_path" ]
+}
+
+command_link_is_exact() {
+    local link_path="$1/$BINARY_NAME"
+    local expected_target="$2/$BINARY_NAME"
+    local actual_target
+
+    [ -L "$link_path" ] || return 1
+    actual_target="$(readlink "$link_path")" || return 1
+    [ "$actual_target" = "$expected_target" ]
+}
+
+validate_command_link() {
+    local link_path="$1/$BINARY_NAME"
+
+    if [ -L "$link_path" ]; then
+        if command_link_is_managed "$1" "$2"; then
+            return 0
+        fi
+        echo "Error: a foreign symlink already exists at $link_path." >&2
+        return 1
+    fi
+
+    if [ -e "$link_path" ]; then
+        echo "Error: an unmanaged file already exists at $link_path." >&2
+        return 1
+    fi
+
+    return 0
+}
+
+# --- Transaction cleanup ---
+
+report_move_ambiguity() {
+    echo "Error: Could not determine the result of the $1 rename." >&2
+    echo "Recovery paths were preserved for manual inspection:" >&2
+    echo "  $2" >&2
+    echo "  $3" >&2
+    PRESERVE_TRANSACTION=1
+}
+
+reconcile_backup_move() {
+    if path_exists "$LIB_DIR" && ! path_exists "$TRANSACTION_DIR/backup"; then
+        BACKUP_MOVE_INTENT=0
+        BACKUP_ACTIVE=0
+        return 0
+    fi
+    if ! path_exists "$LIB_DIR" && path_exists "$TRANSACTION_DIR/backup"; then
+        BACKUP_MOVE_INTENT=0
+        BACKUP_ACTIVE=1
+        return 0
+    fi
+
+    BACKUP_MOVE_INTENT=0
+    LIBRARY_STATE_AMBIGUOUS=1
+    report_move_ambiguity "backup" "$LIB_DIR" "$TRANSACTION_DIR/backup"
+    return 1
+}
+
+reconcile_payload_move() {
+    if path_exists "$TRANSACTION_DIR/payload" && ! path_exists "$LIB_DIR"; then
+        NEW_MOVE_INTENT=0
+        NEW_ACTIVE=0
+        return 0
+    fi
+    if ! path_exists "$TRANSACTION_DIR/payload" && path_exists "$LIB_DIR"; then
+        NEW_MOVE_INTENT=0
+        NEW_ACTIVE=1
+        return 0
+    fi
+
+    NEW_MOVE_INTENT=0
+    LIBRARY_STATE_AMBIGUOUS=1
+    report_move_ambiguity "payload promotion" "$TRANSACTION_DIR/payload" "$LIB_DIR"
+    return 1
+}
+
+reconcile_new_rollback() {
+    if path_exists "$LIB_DIR" && ! path_exists "$TRANSACTION_DIR/payload"; then
+        NEW_ROLLBACK_INTENT=0
+        NEW_ACTIVE=1
+        return 0
+    fi
+    if ! path_exists "$LIB_DIR" && path_exists "$TRANSACTION_DIR/payload"; then
+        NEW_ROLLBACK_INTENT=0
+        NEW_ACTIVE=0
+        return 0
+    fi
+
+    NEW_ROLLBACK_INTENT=0
+    LIBRARY_STATE_AMBIGUOUS=1
+    report_move_ambiguity "new-library rollback" "$LIB_DIR" "$TRANSACTION_DIR/payload"
+    return 1
+}
+
+reconcile_backup_restore() {
+    if path_exists "$TRANSACTION_DIR/backup" && ! path_exists "$LIB_DIR"; then
+        BACKUP_RESTORE_INTENT=0
+        BACKUP_ACTIVE=1
+        return 0
+    fi
+    if ! path_exists "$TRANSACTION_DIR/backup" && path_exists "$LIB_DIR"; then
+        BACKUP_RESTORE_INTENT=0
+        BACKUP_ACTIVE=0
+        return 0
+    fi
+
+    BACKUP_RESTORE_INTENT=0
+    LIBRARY_STATE_AMBIGUOUS=1
+    report_move_ambiguity "backup restoration" "$TRANSACTION_DIR/backup" "$LIB_DIR"
+    return 1
+}
+
+report_backup_recovery() {
+    PRESERVE_TRANSACTION=1
+    echo "Error: automatic restoration failed." >&2
+    if path_exists "$TRANSACTION_DIR/backup"; then
+        echo "The previous installation backup was preserved at:" >&2
+        echo "  $TRANSACTION_DIR/backup" >&2
+        echo "Move it back to $LIB_DIR manually after resolving the filesystem error." >&2
+    else
+        echo "Installer recovery data was preserved at:" >&2
+        echo "  $TRANSACTION_DIR" >&2
+        echo "The replacement library may still be at $LIB_DIR." >&2
+    fi
+}
+
+rollback_install() {
+    if [ "$NEW_ACTIVE" -eq 1 ]; then
+        if ! path_exists "$LIB_DIR" || path_exists "$TRANSACTION_DIR/payload"; then
+            report_backup_recovery
+            return 1
+        fi
+
+        NEW_ROLLBACK_INTENT=1
+        if ! mv "$LIB_DIR" "$TRANSACTION_DIR/payload"; then
+            :
+        fi
+        if ! reconcile_new_rollback; then
+            report_backup_recovery
+            return 1
+        fi
+        if [ "$NEW_ACTIVE" -ne 0 ]; then
+            report_backup_recovery
+            return 1
+        fi
+    fi
+
+    if [ "$BACKUP_ACTIVE" -eq 1 ]; then
+        if ! path_exists "$TRANSACTION_DIR/backup" || path_exists "$LIB_DIR"; then
+            report_backup_recovery
+            return 1
+        fi
+
+        BACKUP_RESTORE_INTENT=1
+        if ! mv "$TRANSACTION_DIR/backup" "$LIB_DIR"; then
+            :
+        fi
+        if ! reconcile_backup_restore; then
+            report_backup_recovery
+            return 1
+        fi
+        if [ "$BACKUP_ACTIVE" -ne 0 ]; then
+            report_backup_recovery
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+remove_created_link() {
+    local link_path="$INSTALL_DIR/$BINARY_NAME"
+
+    if [ "$LINK_CREATED" -ne 1 ]; then
+        return 0
+    fi
+
+    if command_link_is_exact "$INSTALL_DIR" "$LIB_DIR"; then
+        if ! rm -f -- "$link_path"; then
+            echo "Error: Could not remove the command link created by this installer." >&2
+            return 1
+        fi
+    elif path_exists "$link_path"; then
+        echo "Warning: The command path changed during installation and was preserved: $link_path" >&2
+    fi
+
+    LINK_CREATED=0
+    return 0
+}
+
+cleanup_install() {
+    local status=$?
+
+    trap - EXIT
+    trap '' HUP INT TERM
+
+    if [ "$COMMITTED" -eq 0 ]; then
+        if [ "$BACKUP_MOVE_INTENT" -eq 1 ] && ! reconcile_backup_move; then
+            status=1
+        fi
+        if [ "$NEW_MOVE_INTENT" -eq 1 ] && ! reconcile_payload_move; then
+            status=1
+        fi
+        if [ "$LINK_CREATE_INTENT" -eq 1 ]; then
+            LINK_CREATE_INTENT=0
+            if command_link_is_exact "$INSTALL_DIR" "$LIB_DIR"; then
+                echo "Warning: Command-link creation was interrupted; the ambiguous link was preserved: $INSTALL_DIR/$BINARY_NAME" >&2
+            fi
+        fi
+
+        if ! remove_created_link; then
+            status=1
+        fi
+
+        if [ "$LIBRARY_STATE_AMBIGUOUS" -eq 0 ] &&
+           { [ "$BACKUP_ACTIVE" -eq 1 ] || [ "$NEW_ACTIVE" -eq 1 ]; }; then
+            if ! rollback_install; then
+                status=1
+            fi
+        fi
+    fi
+
+    if [ "$BACKUP_ACTIVE" -eq 1 ] || [ "$NEW_ACTIVE" -eq 1 ] ||
+       [ "$BACKUP_MOVE_INTENT" -eq 1 ] || [ "$BACKUP_RESTORE_INTENT" -eq 1 ] ||
+       [ "$NEW_MOVE_INTENT" -eq 1 ] || [ "$NEW_ROLLBACK_INTENT" -eq 1 ]; then
+        PRESERVE_TRANSACTION=1
+    fi
+
+    if [ -n "$DOWNLOAD_DIR" ] && [ -d "$DOWNLOAD_DIR" ]; then
+        if ! rm -rf -- "$DOWNLOAD_DIR"; then
+            status=1
+        fi
+    fi
+    if [ "$PRESERVE_TRANSACTION" -eq 0 ] &&
+       [ -n "$TRANSACTION_DIR" ] && [ -d "$TRANSACTION_DIR" ]; then
+        if ! rm -rf -- "$TRANSACTION_DIR"; then
+            status=1
+        fi
+    fi
+
+    exit "$status"
+}
+
 # --- Main ---
 
 main() {
-    local platform version artifact url
+    local platform version artifact url archive checksum
+    local expected actual lib_parent marker_path
+
+    LIB_DIR="$(validate_lib_dir "$LIB_DIR")" || exit 1
+    INSTALL_DIR="$(validate_install_dir "$INSTALL_DIR" "$LIB_DIR")" || exit 1
+    validate_command_link "$INSTALL_DIR" "$LIB_DIR" || exit 1
 
     platform="$(detect_platform)"
     version="$(resolve_version)"
@@ -113,13 +594,15 @@ main() {
 
     url="https://github.com/$REPO/releases/download/v${version}/${artifact}.tar.gz"
 
-    # Download to temp file
-    local tmpfile tmpsha
-    tmpfile="$(mktemp)"
-    tmpsha="$(mktemp)"
-    trap 'rm -f "$tmpfile" "$tmpsha"' EXIT
+    DOWNLOAD_DIR="$(mktemp -d)"
+    archive="$DOWNLOAD_DIR/$artifact.tar.gz"
+    checksum="$DOWNLOAD_DIR/$artifact.tar.gz.sha256"
+    trap cleanup_install EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
 
-    if ! curl -fsSL -o "$tmpfile" "$url"; then
+    if ! curl -fsSL -o "$archive" "$url"; then
         echo "Error: Download failed." >&2
         echo "  URL: $url" >&2
         echo "" >&2
@@ -131,10 +614,9 @@ main() {
     fi
 
     # Verify checksum if sidecar is available
-    if curl -fsSL -o "$tmpsha" "${url}.sha256" 2>/dev/null; then
-        local expected actual
-        expected="$(awk '{print $1}' "$tmpsha")"
-        actual="$(sha256_file "$tmpfile")"
+    if curl -fsSL -o "$checksum" "${url}.sha256" 2>/dev/null; then
+        expected="$(awk '{print $1}' "$checksum")"
+        actual="$(sha256_file "$archive")"
         if [ "$actual" != "$expected" ]; then
             echo "Error: Checksum mismatch — download may be corrupt." >&2
             echo "  Expected: $expected" >&2
@@ -145,20 +627,104 @@ main() {
         echo "Warning: checksum file not found for v${version}; skipping verification." >&2
     fi
 
-    # Remove previous installation if present
-    if [ -d "$LIB_DIR" ]; then
-        rm -rf "$LIB_DIR"
+    lib_parent="${LIB_DIR%/*}"
+    mkdir -p "$lib_parent"
+    TRANSACTION_DIR="$(mktemp -d "$lib_parent/.deals-install.XXXXXX")"
+    mkdir "$TRANSACTION_DIR/payload"
+
+    if ! tar xzf "$archive" -C "$TRANSACTION_DIR/payload" --strip-components=1; then
+        echo "Error: Could not extract downloaded archive." >&2
+        exit 1
     fi
 
-    # Extract archive to lib directory
-    mkdir -p "$LIB_DIR"
-    tar xzf "$tmpfile" -C "$LIB_DIR" --strip-components=1
+    if [ ! -f "$TRANSACTION_DIR/payload/$BINARY_NAME" ] || [ -L "$TRANSACTION_DIR/payload/$BINARY_NAME" ]; then
+        echo "Error: Downloaded archive does not contain the expected $BINARY_NAME binary." >&2
+        exit 1
+    fi
 
-    chmod +x "${LIB_DIR}/${BINARY_NAME}"
+    marker_path="$TRANSACTION_DIR/payload/$INSTALL_MARKER_NAME"
+    if path_exists "$marker_path"; then
+        echo "Error: Downloaded archive contains the reserved installer marker." >&2
+        exit 1
+    fi
+    printf '%s' "$INSTALL_MARKER_CONTENT" > "$marker_path"
 
-    # Create symlink in INSTALL_DIR
+    chmod +x "$TRANSACTION_DIR/payload/$BINARY_NAME"
+    if [ ! -x "$TRANSACTION_DIR/payload/$BINARY_NAME" ]; then
+        echo "Error: Downloaded $BINARY_NAME binary is not executable." >&2
+        exit 1
+    fi
+    if ! "$TRANSACTION_DIR/payload/$BINARY_NAME" --version >/dev/null 2>&1; then
+        echo "Error: Downloaded $BINARY_NAME binary failed its staged --version check." >&2
+        exit 1
+    fi
+
     mkdir -p "$INSTALL_DIR"
-    ln -sf "${LIB_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+    validate_command_link "$INSTALL_DIR" "$LIB_DIR" || exit 1
+
+    if path_exists "$LIB_DIR"; then
+        BACKUP_MOVE_INTENT=1
+        if mv "$LIB_DIR" "$TRANSACTION_DIR/backup"; then
+            if ! reconcile_backup_move || [ "$BACKUP_ACTIVE" -ne 1 ]; then
+                echo "Error: Could not confirm preservation of the previous installation." >&2
+                exit 1
+            fi
+        else
+            reconcile_backup_move || true
+            echo "Error: Could not preserve the previous installation." >&2
+            exit 1
+        fi
+    fi
+
+    NEW_MOVE_INTENT=1
+    if mv "$TRANSACTION_DIR/payload" "$LIB_DIR"; then
+        if ! reconcile_payload_move || [ "$NEW_ACTIVE" -ne 1 ]; then
+            echo "Error: Could not confirm installation of the new library." >&2
+            exit 1
+        fi
+    else
+        reconcile_payload_move || true
+        echo "Error: Could not install the new library." >&2
+        exit 1
+    fi
+
+    if [ ! -L "$INSTALL_DIR/$BINARY_NAME" ]; then
+        LINK_CREATE_INTENT=1
+        if ln -s "$LIB_DIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"; then
+            LINK_CREATE_INTENT=0
+            if command_link_is_exact "$INSTALL_DIR" "$LIB_DIR"; then
+                LINK_CREATED=1
+            else
+                echo "Error: Could not confirm installation of the command symlink." >&2
+                exit 1
+            fi
+        else
+            LINK_CREATE_INTENT=0
+            if command_link_is_exact "$INSTALL_DIR" "$LIB_DIR"; then
+                echo "Warning: Command-link ownership is ambiguous; the link was preserved: $INSTALL_DIR/$BINARY_NAME" >&2
+            fi
+            echo "Error: Could not install the command symlink." >&2
+            exit 1
+        fi
+    fi
+
+    if ! command_link_is_managed "$INSTALL_DIR" "$LIB_DIR"; then
+        echo "Error: Installed command link does not resolve to the new $BINARY_NAME binary." >&2
+        exit 1
+    fi
+    if ! "$INSTALL_DIR/$BINARY_NAME" --version >/dev/null 2>&1; then
+        echo "Error: Installed command failed its final --version check." >&2
+        exit 1
+    fi
+
+    COMMITTED=1
+    rm -rf -- "$TRANSACTION_DIR"
+    TRANSACTION_DIR=""
+    BACKUP_ACTIVE=0
+    NEW_ACTIVE=0
+    LINK_CREATED=0
+    rm -rf -- "$DOWNLOAD_DIR"
+    DOWNLOAD_DIR=""
 
     echo ""
     echo "Installed to ${LIB_DIR}/"
@@ -201,4 +767,6 @@ main() {
     echo "  deals login --external --via-file /tmp/url.txt"
 }
 
-main
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+    main "$@"
+fi

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,6 @@ REPO="chauduyphanvu/audible-deals"
 INSTALL_DIR="${INSTALL_DIR-$HOME/.local/bin}"
 LIB_DIR="${LIB_DIR-$HOME/.local/lib/deals}"
 BINARY_NAME="deals"
-FALLBACK_VERSION="0.9.1"
 INSTALL_MARKER_NAME=".audible-deals-install"
 INSTALL_MARKER_CONTENT="repository=chauduyphanvu/audible-deals"
 
@@ -86,18 +85,24 @@ resolve_version() {
         return
     fi
 
-    local latest
-    latest="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
-        | grep '"tag_name"' | head -1 | cut -d'"' -f4)" || true
+    local release_prefix latest_url latest
+    release_prefix="https://github.com/$REPO/releases/tag/"
 
-    if [ -z "$latest" ]; then
-        echo "Warning: Could not determine latest version from GitHub API; falling back to v${FALLBACK_VERSION}" >&2
-        echo "${FALLBACK_VERSION}"
-        return
+    if latest_url="$(curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.com/$REPO/releases/latest" 2>/dev/null)"; then
+        case "$latest_url" in
+            "$release_prefix"*)
+                latest="${latest_url#"$release_prefix"}"
+                latest="${latest#v}"
+                if [[ "$latest" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.]+)?$ ]]; then
+                    echo "$latest"
+                    return
+                fi
+                ;;
+        esac
     fi
 
-    # Strip leading 'v' if present
-    echo "${latest#v}"
+    echo "Error: Could not resolve the latest release from GitHub; retry or set VERSION explicitly." >&2
+    return 1
 }
 
 # --- Checksum helper ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Issues = "https://github.com/chauduyphanvu/audible-deals/issues"
 Changelog = "https://github.com/chauduyphanvu/audible-deals/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "ruff>=0.15", "pre-commit>=4.0"]
+dev = ["pytest>=8.0", "ruff>=0.15,<0.16", "pre-commit>=4.0"]
 docs = ["mkdocs-material>=9.7,<10"]
 
 [build-system]

--- a/src/audible_deals/cli/foryou.py
+++ b/src/audible_deals/cli/foryou.py
@@ -18,6 +18,7 @@ from audible_deals.cli.helpers import (
     _credit_price,
     _currency,
     _get_client,
+    _report_partial_series_outcomes,
     _resolve_output_quiet,
 )
 from audible_deals.validation import NONNEGATIVE_FLOAT, NONNEGATIVE_INT, RATING_FLOAT
@@ -33,7 +34,6 @@ from audible_deals.presentation.terminal import (
     console,
     create_scan_progress,
     safe_markup,
-    safe_text,
 )
 from audible_deals.result_models import FilterContext
 from audible_deals.results_cache import load_dismissed_asins
@@ -321,35 +321,6 @@ def _fetch_candidates(
     return list(candidates.values()), series_matches, tuple(failures), tuple(incomplete)
 
 
-def _report_for_me_series_outcomes(
-    failures: tuple[str, ...],
-    incomplete: tuple[str, ...],
-    total: int,
-    *,
-    json_flag: bool,
-) -> None:
-    if not failures and not incomplete:
-        return
-    outcomes = []
-    if failures:
-        outcomes.append(f"{len(failures)} failed")
-    if incomplete:
-        outcomes.append(f"{len(incomplete)} incomplete")
-    summary = (
-        f"Partial results: {total - len(failures)}/{total} series scanned; "
-        f"{'; '.join(outcomes)}."
-    )
-    details = (*failures, *incomplete)
-    if json_flag:
-        click.echo(summary, err=True)
-        for detail in details:
-            click.echo(f"  {safe_text(detail)}", err=True)
-    else:
-        console.print(f"[yellow]{safe_markup(summary)}[/yellow]")
-        for detail in details:
-            console.print(f"[dim]  {safe_markup(detail)}[/dim]")
-
-
 @click.command("for-me")
 @click.option(
     "--refresh",
@@ -595,7 +566,7 @@ def for_me(
             show_progress=not json_flag,
         )
 
-    _report_for_me_series_outcomes(
+    _report_partial_series_outcomes(
         failures,
         incomplete,
         len(series),

--- a/src/audible_deals/cli/helpers.py
+++ b/src/audible_deals/cli/helpers.py
@@ -9,8 +9,7 @@ import click
 from audible_deals.client import DealsClient
 from audible_deals.config_store import load_profiles
 from audible_deals.constants import LOCALE_CURRENCY
-from audible_deals.validation import validate_finite_number
-from audible_deals.presentation.terminal import console, safe_markup
+from audible_deals.presentation.terminal import console, safe_markup, safe_text
 from audible_deals.results_cache import (
     load_dismissed_asins,
     load_seen_asins,
@@ -18,6 +17,7 @@ from audible_deals.results_cache import (
 )
 from audible_deals.selectors import resolve_selectors
 from audible_deals.settings import profile_validation_error
+from audible_deals.validation import validate_finite_number
 
 _CL = click.core.ParameterSource.COMMANDLINE
 
@@ -144,3 +144,32 @@ def _resolve_output_quiet(ctx: click.Context, output, json_flag, quiet) -> bool:
     if json_flag:
         console.file = sys.stderr
     return quiet
+
+
+def _report_partial_series_outcomes(
+    failures: tuple[str, ...],
+    incomplete: tuple[str, ...],
+    total: int,
+    *,
+    json_flag: bool,
+) -> None:
+    if not failures and not incomplete:
+        return
+    completed = total - len(failures)
+    outcomes = []
+    if failures:
+        outcomes.append(f"{len(failures)} failed")
+    if incomplete:
+        outcomes.append(f"{len(incomplete)} incomplete")
+    summary = (
+        f"Partial results: {completed}/{total} series scanned; {'; '.join(outcomes)}."
+    )
+    details = (*failures, *incomplete)
+    if json_flag:
+        click.echo(summary, err=True)
+        for detail in details:
+            click.echo(f"  {safe_text(detail)}", err=True)
+    else:
+        console.print(f"[yellow]{safe_markup(summary)}[/yellow]")
+        for detail in details:
+            console.print(f"[dim]  {safe_markup(detail)}[/dim]")

--- a/src/audible_deals/cli/series.py
+++ b/src/audible_deals/cli/series.py
@@ -14,6 +14,7 @@ from audible_deals.cli.helpers import (
     _credit_price,
     _currency,
     _get_client,
+    _report_partial_series_outcomes,
     _resolve_output_quiet,
 )
 from audible_deals.client import CatalogSearchRequest, DealsClient
@@ -24,7 +25,6 @@ from audible_deals.presentation.terminal import (
     console,
     create_scan_progress,
     safe_markup,
-    safe_text,
 )
 from audible_deals.product import Product
 from audible_deals.result_models import FilterContext
@@ -211,35 +211,6 @@ def _fetch_series_candidates(
         asin: tuple(targets) for asin, targets in candidate_series_lists.items()
     }
     return all_candidates, candidate_series, tuple(failures), tuple(incomplete)
-
-
-def _report_series_failures(
-    failures: tuple[str, ...],
-    incomplete: tuple[str, ...],
-    total: int,
-    *,
-    json_flag: bool,
-) -> None:
-    if not failures and not incomplete:
-        return
-    completed = total - len(failures)
-    outcomes = []
-    if failures:
-        outcomes.append(f"{len(failures)} failed")
-    if incomplete:
-        outcomes.append(f"{len(incomplete)} incomplete")
-    summary = (
-        f"Partial results: {completed}/{total} series scanned; {'; '.join(outcomes)}."
-    )
-    details = (*failures, *incomplete)
-    if json_flag:
-        click.echo(summary, err=True)
-        for detail in details:
-            click.echo(f"  {safe_text(detail)}", err=True)
-    else:
-        console.print(f"[yellow]{safe_markup(summary)}[/yellow]")
-        for detail in details:
-            console.print(f"[dim]  {safe_markup(detail)}[/dim]")
 
 
 def _series_gaps_report(
@@ -556,7 +527,7 @@ def series(
             )
         )
 
-    _report_series_failures(
+    _report_partial_series_outcomes(
         failures,
         incomplete,
         len(invested_sorted),

--- a/src/audible_deals/client.py
+++ b/src/audible_deals/client.py
@@ -562,16 +562,6 @@ class DealsClient:
             raise ValueError(f"Product not found: {asin}")
         return results[0]
 
-    def get_series_products(self, series_asin: str) -> list[_product.Product]:
-        """Fetch all products in a series by its ASIN.
-
-        Returns an empty list if the series is not found.
-        """
-        child_asins = self._get_series_child_asins(series_asin)
-        if not child_asins:
-            return []
-        return self.get_products_batch(child_asins)
-
     def _get_series_child_asins(self, series_asin: str) -> list[str]:
         resp = self._transport.request(
             f"1.0/catalog/products/{series_asin}",

--- a/src/audible_deals/price_history.py
+++ b/src/audible_deals/price_history.py
@@ -464,18 +464,6 @@ def load_all_price_histories(locale: str = "us") -> dict[str, list[dict]]:
     return result
 
 
-def delete_price_histories(asins: list[str], locale: str = "us") -> int:
-    """Delete the history files for the given ASINs. Returns the number removed."""
-    removed = 0
-    for asin in asins:
-        hist_file = constants.HISTORY_DIR / f"{asin}.json"
-        with _history_update_lock(hist_file):
-            raw = load_json_file(hist_file, dict, f"price history {asin}")
-            if _delete_marketplace_history(hist_file, raw, locale):
-                removed += 1
-    return removed
-
-
 def _delete_marketplace_history(hist_file: Path, raw: dict, locale: str) -> bool:
     markets = raw.get(_MARKETPLACES_KEY)
     if not isinstance(markets, dict) or locale not in markets:

--- a/src/audible_deals/result_publication.py
+++ b/src/audible_deals/result_publication.py
@@ -28,7 +28,6 @@ from audible_deals.product import Product
 from audible_deals.refresh_eligibility import mark_refresh_eligible
 from audible_deals.result_models import DiscoveryResult, ResultRecipe, ResultSession
 from audible_deals.results_cache import (
-    save_last_results,
     save_result_session,
     save_seen_asins,
 )
@@ -57,13 +56,11 @@ class ResultPublicationRequest:
     quiet: bool
     max_price: float | None
     currency: str
+    session_spec: ResultSessionSpec
     interactive: bool = False
     show_url: bool = False
-    write_cache: bool = True
-    record_price_history: bool = True
     credit_price: float | None = None
     candidates: tuple[Product, ...] = ()
-    session_spec: ResultSessionSpec | None = None
     json_writer: Callable[[str], object] = print
 
     def __post_init__(self) -> None:
@@ -75,7 +72,7 @@ class ResultPublicationOutcome:
     products: tuple[Product, ...]
     serialized: tuple[dict, ...]
     total_before_limit: int
-    session: ResultSession | None = None
+    session: ResultSession
 
 
 def record_prices_safely(
@@ -104,14 +101,10 @@ def mark_refresh_eligible_safely(products: list[Product]) -> None:
 def _session_for_request(
     request: ResultPublicationRequest,
     visible: list[Product],
-    histories: dict[str, list[dict]] | None,
-) -> ResultSession | None:
+    histories: dict[str, list[dict]],
+) -> ResultSession:
     spec = request.session_spec
-    if spec is None:
-        return None
     constraints = copy.deepcopy(spec.constraints)
-    if histories is None:
-        histories = {}
     constraints["history_percentiles"] = hist_percentiles(
         list(request.candidates), histories
     )
@@ -153,7 +146,7 @@ def publish_discovery(
             console.print(f"[green]{safe_markup(export_message)}[/green]")
 
     histories = request.result.histories
-    if histories is None and request.session_spec is not None:
+    if histories is None:
         histories = {
             history_key(product.asin, product.locale): load_price_history(
                 product.asin, product.locale
@@ -174,23 +167,14 @@ def publish_discovery(
     serialized = serialized_all[: len(visible)]
 
     def commit_presentation() -> None:
-        if request.record_price_history:
-            observation_date = (
-                datetime.datetime.fromisoformat(session.timestamp).date()
-                if session is not None
-                else None
-            )
-            record_prices_safely(surfaced, observation_date=observation_date)
+        observation_date = datetime.datetime.fromisoformat(session.timestamp).date()
+        record_prices_safely(surfaced, observation_date=observation_date)
         mark_refresh_eligible_safely(surfaced)
-        if request.write_cache:
-            try:
-                if session is not None:
-                    save_result_session(session)
-                else:
-                    save_last_results(request.title, serialized_all)
-            except Exception:
-                logger.warning("Could not save last result session", exc_info=True)
-            save_seen_asins({product.asin for product in visible})
+        try:
+            save_result_session(session)
+        except Exception:
+            logger.warning("Could not save last result session", exc_info=True)
+        save_seen_asins({product.asin for product in visible})
 
     visible_result = dataclasses.replace(
         request.result,

--- a/src/audible_deals/scheduler.py
+++ b/src/audible_deals/scheduler.py
@@ -241,8 +241,29 @@ def _cron_uninstall() -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _quote_windows_task_token(value: str) -> str:
+    trailing_backslashes = len(value) - len(value.rstrip("\\"))
+    if trailing_backslashes:
+        value += "\\" * trailing_backslashes
+    return f'"{value}"'
+
+
+def generate_windows_task_command(cmd: list[str], log_path: Path) -> str:
+    if not cmd:
+        raise SchedulerError("Windows scheduled task command cannot be empty")
+    tokens = [str(token) for token in cmd]
+    log = str(log_path)
+    unsafe = {'"', "<", ">", "|", "\0", "\r", "\n", "%"}
+    if any(char in value for value in [*tokens, log] for char in unsafe):
+        raise SchedulerError(
+            "Windows scheduled task command contains unsafe characters"
+        )
+    quoted = " ".join(_quote_windows_task_token(token) for token in tokens)
+    return f'cmd.exe /D /S /V:OFF /C "{quoted} >> "{log}" 2>&1"'
+
+
 def _schtasks_install(interval_s: int, log_path: Path) -> str:
-    cmd = " ".join(f'"{c}"' for c in track_command())
+    cmd = generate_windows_task_command(track_command(), log_path)
     if interval_s % 60:
         raise SchedulerError(
             "Windows Task Scheduler cannot represent intervals with seconds; use a whole number of minutes"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,30 @@ def make_product(**overrides) -> Product:
     return Product(**defaults)
 
 
+def make_series_products_batch(
+    products=None,
+    *,
+    failures=None,
+    missing_asins=None,
+    product_failures=None,
+):
+    return SeriesProductsBatch(
+        products={
+            series_asin: tuple(series_products)
+            for series_asin, series_products in (products or {}).items()
+        },
+        failures=dict(failures or {}),
+        missing_asins={
+            series_asin: tuple(asins)
+            for series_asin, asins in (missing_asins or {}).items()
+        },
+        product_failures={
+            series_asin: tuple(errors)
+            for series_asin, errors in (product_failures or {}).items()
+        },
+    )
+
+
 @pytest.fixture
 def sample_product():
     return make_product()
@@ -320,18 +344,8 @@ def mock_client(monkeypatch):
             results.append(CatalogSearchResult(tuple(pages), error))
         return results
 
-    def get_series_products_many(series_asins):
-        products = {}
-        failures = {}
-        for series_asin in dict.fromkeys(series_asins):
-            try:
-                products[series_asin] = tuple(client.get_series_products(series_asin))
-            except Exception as exc:
-                failures[series_asin] = exc
-        return SeriesProductsBatch(products, failures, {})
-
     client.search_segments.side_effect = search_segments
-    client.get_series_products_many.side_effect = get_series_products_many
+    client.get_series_products_many.return_value = make_series_products_batch()
 
     def _get_mock(locale):
         return client

--- a/tests/test_cli_catalog_routes.py
+++ b/tests/test_cli_catalog_routes.py
@@ -10,7 +10,7 @@ from audible_deals.cli import cli
 from audible_deals.serialization import (
     serialize_product as _serialize_product,
 )
-from tests.conftest import make_product
+from tests.conftest import make_product, make_series_products_batch
 
 
 def _routes_run(runner, args, **kwargs):
@@ -545,7 +545,9 @@ class TestRoutesZeroLengthFiltering:
             price=14.99,
         )
         mock_client.get_library.return_value = [owned1, owned2]
-        mock_client.get_series_products.return_value = [preorder]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SARC1": [preorder]}
+        )
 
         result = _routes_run(
             CliRunner(),
@@ -715,7 +717,9 @@ class TestRoutesSeriesGapsMode:
     def test_gaps_basic_terminal_output(self, tmp_config, mock_client):
         """Gaps mode runs without error; missing book appears in JSON for verification."""
         mock_client.get_library.return_value = self._make_library()
-        mock_client.get_series_products.return_value = self._make_catalog()
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"EXPANSE1": self._make_catalog()}
+        )
 
         # Terminal display goes through Rich console (not captured by CliRunner).
         # Verify the command succeeds and produces correct JSON in a parallel call.
@@ -739,7 +743,9 @@ class TestRoutesSeriesGapsMode:
     def test_gaps_json_shape(self, tmp_config, mock_client):
         """--gaps --json emits correct per-series structure."""
         mock_client.get_library.return_value = self._make_library()
-        mock_client.get_series_products.return_value = self._make_catalog()
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"EXPANSE1": self._make_catalog()}
+        )
 
         result = _routes_run(
             CliRunner(),
@@ -806,7 +812,9 @@ class TestRoutesSeriesGapsMode:
         )
         mock_client.get_library.return_value = [owned1, owned2]
         # Catalog has the same books already owned — no new candidates
-        mock_client.get_series_products.return_value = [owned1, owned2]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"CSER1": [owned1, owned2]}
+        )
 
         result = _routes_run(
             CliRunner(),
@@ -852,7 +860,9 @@ class TestRoutesSeriesGapsMode:
             length_minutes=600,
         )
         mock_client.get_library.return_value = [owned, owned2]
-        mock_client.get_series_products.return_value = [owned, owned2, miss5, miss3]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SORT1": [owned, owned2, miss5, miss3]}
+        )
 
         result = _routes_run(
             CliRunner(),

--- a/tests/test_cli_library_series.py
+++ b/tests/test_cli_library_series.py
@@ -457,13 +457,18 @@ class TestSeriesCommand:
         mock_client.get_series_products_many.return_value = make_series_products_batch(
             {"SER_BETA": [lib[2], lib[3], beta]},
             failures={"SER_ALPHA": failure},
+            missing_asins={"SER_BETA": ("B4",)},
         )
 
         result = CliRunner().invoke(cli, ["series"])
 
         assert result.exit_code == 0, result.output
-        assert "Partial results: 1/2 series scanned; 1 failed" in result.output
-        assert "Alpha Series: RuntimeError: temporary failure" in result.output
+        assert (
+            "Partial results: 1/2 series scanned; 1 failed; 1 incomplete.\n"
+            "  Alpha Series: RuntimeError: temporary failure\n"
+            "  Beta Series: 1 product(s) unavailable\n"
+        ) in result.stdout
+        assert "Partial results:" not in result.stderr
         assert "Beta Book 3" in result.output
 
     def test_series_reports_missing_child_products(self, tmp_config, mock_client):

--- a/tests/test_cli_library_series.py
+++ b/tests/test_cli_library_series.py
@@ -8,7 +8,6 @@ import json
 from click.testing import CliRunner
 
 import audible_deals.constants as constants_mod
-from audible_deals.client import SeriesProductsBatch
 from audible_deals.cli import cli
 from audible_deals.results_cache import load_result_session, save_dismissed_asins
 from audible_deals.series_identity import (
@@ -16,7 +15,7 @@ from audible_deals.series_identity import (
     series_book_identity,
     series_identity,
 )
-from tests.conftest import make_product
+from tests.conftest import make_product, make_series_products_batch
 
 
 def _mock_library_pages(mock_client, products):
@@ -339,7 +338,9 @@ class TestSeriesCommand:
             series_asin="SER_DISMISSED",
         )
         mock_client.get_library.return_value = lib
-        mock_client.get_series_products.return_value = [dismissed, visible]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_DISMISSED": [dismissed, visible]}
+        )
         save_dismissed_asins({dismissed.asin})
 
         result = CliRunner().invoke(cli, ["series", "--json"])
@@ -371,7 +372,9 @@ class TestSeriesCommand:
             series_asin="SER_GAPS",
         )
         mock_client.get_library.return_value = lib
-        mock_client.get_series_products.return_value = [dismissed]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_GAPS": [dismissed]}
+        )
         save_dismissed_asins({dismissed.asin})
 
         result = CliRunner().invoke(cli, ["series", "--gaps", "--json"])
@@ -380,7 +383,7 @@ class TestSeriesCommand:
         assert json.loads(result.stdout) == []
 
     def test_series_direct_lookup(self, tmp_config, mock_client):
-        """With series_asin, uses direct lookup via get_series_products."""
+        """With series_asin, uses direct batch lookup."""
         lib = [
             make_product(
                 asin="A1",
@@ -405,13 +408,15 @@ class TestSeriesCommand:
             series_name="Alpha Series",
             series_position="3",
         )
-        mock_client.get_series_products.return_value = [lib[0], lib[1], unowned]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": [lib[0], lib[1], unowned]}
+        )
 
         runner = CliRunner()
         result = runner.invoke(cli, ["series"])
         assert result.exit_code == 0, result.output
         assert "Alpha Book 3" in result.output
-        mock_client.get_series_products.assert_called_once_with("SER_ALPHA")
+        mock_client.get_series_products_many.assert_called_once_with(["SER_ALPHA"])
         mock_client.search_pages.assert_not_called()
 
     def test_series_reports_partial_lookup_failures(self, tmp_config, mock_client):
@@ -448,10 +453,11 @@ class TestSeriesCommand:
             series_position="3",
         )
         mock_client.get_library.return_value = lib
-        mock_client.get_series_products.side_effect = [
-            RuntimeError("temporary failure"),
-            [lib[2], lib[3], beta],
-        ]
+        failure = RuntimeError("temporary failure")
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_BETA": [lib[2], lib[3], beta]},
+            failures={"SER_ALPHA": failure},
+        )
 
         result = CliRunner().invoke(cli, ["series"])
 
@@ -476,10 +482,8 @@ class TestSeriesCommand:
             ),
         ]
         mock_client.get_library.return_value = lib
-        mock_client.get_series_products_many.side_effect = None
-        mock_client.get_series_products_many.return_value = SeriesProductsBatch(
-            products={"SER_ALPHA": tuple(lib)},
-            failures={},
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": lib},
             missing_asins={"SER_ALPHA": ("A3",)},
         )
 
@@ -521,7 +525,7 @@ class TestSeriesCommand:
         result = runner.invoke(cli, ["series"])
         assert result.exit_code == 0, result.output
         assert "Alpha Book 3" in result.output
-        mock_client.get_series_products.assert_not_called()
+        mock_client.get_series_products_many.assert_called_once_with([])
         assert mock_client.search_pages.call_count == 1
 
     def test_series_min_books_filters(self, tmp_config, mock_client):
@@ -576,13 +580,15 @@ class TestSeriesCommand:
             series_name="Alpha Series",
             series_position="3",
         )
-        mock_client.get_series_products.return_value = [lib[0], lib[1], unowned_alpha]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": [lib[0], lib[1], unowned_alpha]}
+        )
 
         runner = CliRunner()
         result = runner.invoke(cli, ["series", "--series", "Alpha"])
         assert result.exit_code == 0, result.output
 
-        mock_client.get_series_products.assert_called_once_with("SER_ALPHA")
+        mock_client.get_series_products_many.assert_called_once_with(["SER_ALPHA"])
         assert "Alpha Book 3" in result.output
 
     def test_series_skips_owned(self, tmp_config, mock_client):
@@ -623,7 +629,9 @@ class TestSeriesCommand:
             series_name="Alpha Series",
             series_position="3",
         )
-        mock_client.get_series_products.return_value = [a1, a2, a3]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": [a1, a2, a3]}
+        )
 
         runner = CliRunner()
         result = runner.invoke(cli, ["series"])
@@ -690,7 +698,9 @@ class TestSeriesCommand:
             series_name="Alpha Series",
             series_position="3",
         )
-        mock_client.get_series_products.return_value = [lib[0], lib[1], unowned]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": [lib[0], lib[1], unowned]}
+        )
 
         runner = CliRunner()
         result = runner.invoke(cli, ["series", "--json"])
@@ -773,11 +783,9 @@ class TestSeriesCommand:
             series_position="1-2",
         )
         mock_client.get_library.return_value = owned
-        mock_client.get_series_products.return_value = [
-            alternate_owned,
-            alternate_owned_title,
-            unowned,
-        ]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": [alternate_owned, alternate_owned_title, unowned]}
+        )
 
         result = CliRunner().invoke(cli, ["series", "--json"])
 
@@ -865,12 +873,9 @@ class TestSeriesCommand:
             price=4.0,
         )
         mock_client.get_library.return_value = owned
-        mock_client.get_series_products.return_value = [
-            unavailable,
-            expensive,
-            cheapest,
-            tied,
-        ]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": [unavailable, expensive, cheapest, tied]}
+        )
 
         result = CliRunner().invoke(cli, ["series", "--json"])
 
@@ -917,11 +922,9 @@ class TestSeriesCommand:
             length_minutes=0,
         )
         mock_client.get_library.return_value = owned
-        mock_client.get_series_products.return_value = [
-            unavailable,
-            placeholder,
-            preorder,
-        ]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": [unavailable, placeholder, preorder]}
+        )
 
         result = CliRunner().invoke(cli, ["series", "--json"])
 
@@ -979,11 +982,9 @@ class TestSeriesCommand:
             alternate_edition,
             second,
         ]
-        mock_client.get_series_products.return_value = [
-            catalog_owned_edition,
-            unavailable,
-            placeholder,
-        ]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": [catalog_owned_edition, unavailable, placeholder]}
+        )
 
         result = CliRunner().invoke(cli, ["series", "--gaps", "--json"])
 
@@ -1034,7 +1035,9 @@ class TestSeriesCommand:
             series_position="Books 1 & 3",
         )
         mock_client.get_library.return_value = owned
-        mock_client.get_series_products.return_value = [first, second]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": [first, second]}
+        )
 
         result = CliRunner().invoke(cli, ["series", "--json"])
 
@@ -1076,7 +1079,9 @@ class TestSeriesCommand:
             series_name="Shared Universe",
             series_position="3",
         )
-        mock_client.get_series_products.side_effect = [[shared], [shared]]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": [shared], "SER_BETA": [shared]}
+        )
 
         result = CliRunner().invoke(cli, ["series", "--gaps", "--json"])
 
@@ -1119,29 +1124,33 @@ class TestSeriesCommand:
                 series_position="2",
             ),
         ]
-        mock_client.get_series_products.return_value = [
-            make_product(
-                asin="A3",
-                title="Unavailable Book",
-                series_name="Alpha Series",
-                series_position="3",
-                price=None,
-            ),
-            make_product(
-                asin="A4",
-                title="Affordable Book",
-                series_name="Alpha Series",
-                series_position="4",
-                price=4.0,
-            ),
-            make_product(
-                asin="A5",
-                title="Expensive Book",
-                series_name="Alpha Series",
-                series_position="5",
-                price=6.0,
-            ),
-        ]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {
+                "SER_ALPHA": [
+                    make_product(
+                        asin="A3",
+                        title="Unavailable Book",
+                        series_name="Alpha Series",
+                        series_position="3",
+                        price=None,
+                    ),
+                    make_product(
+                        asin="A4",
+                        title="Affordable Book",
+                        series_name="Alpha Series",
+                        series_position="4",
+                        price=4.0,
+                    ),
+                    make_product(
+                        asin="A5",
+                        title="Expensive Book",
+                        series_name="Alpha Series",
+                        series_position="5",
+                        price=6.0,
+                    ),
+                ]
+            }
+        )
 
         result = CliRunner().invoke(cli, ["series", "--gaps", "--json", *options])
 
@@ -1172,7 +1181,9 @@ class TestSeriesCommand:
             price=None,
         )
         mock_client.get_library.return_value = owned
-        mock_client.get_series_products.return_value = [unavailable]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SER_ALPHA": [unavailable]}
+        )
 
         result = CliRunner().invoke(cli, ["series", "--gaps"])
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -51,11 +51,16 @@ def make_curl_shim(directory: Path) -> None:
         f"""#!/bin/bash
 set -eu
 output=""
+write_format=""
 url=""
 while [ "$#" -gt 0 ]; do
     case "$1" in
         -o)
             output="$2"
+            shift 2
+            ;;
+        -w)
+            write_format="$2"
             shift 2
             ;;
         -*)
@@ -67,6 +72,16 @@ while [ "$#" -gt 0 ]; do
             ;;
     esac
 done
+printf '%s\n' "$url" >> "$TEST_CURL_LOG"
+if [ "$url" = "https://github.com/chauduyphanvu/audible-deals/releases/latest" ]; then
+    [ "$output" = "/dev/null" ] || exit 64
+    [ "$write_format" = '%{{url_effective}}' ] || exit 64
+    if [ "${{TEST_LATEST_FAIL:-0}}" = "1" ]; then
+        exit 22
+    fi
+    printf '%s' "${{TEST_LATEST_URL:-}}"
+    exit 0
+fi
 if [ "${{TEST_DOWNLOAD_FAIL:-0}}" = "1" ] && [[ "$url" != *.sha256 ]]; then
     exit 22
 fi
@@ -192,6 +207,7 @@ def base_environment(
             "SHELL": BASH,
             "TEST_ARCHIVE": str(archive),
             "TEST_CHECKSUM": str(checksum),
+            "TEST_CURL_LOG": str(tmp_path / "curl.log"),
             "TMPDIR": str(download_root),
             "VERSION": "1.2.3",
         }
@@ -505,6 +521,119 @@ def test_rejects_reverse_install_path_overlap(tmp_path: Path) -> None:
     assert "must not overlap" in result.stderr
     assert not (install_dir / "deals").exists()
     assert list((tmp_path / "downloads").iterdir()) == []
+
+
+@pytest.mark.parametrize("configured_version", ["2.3.4", "v2.3.4"])
+def test_explicit_version_bypasses_latest_lookup_and_normalizes_leading_v(
+    tmp_path: Path, configured_version: str
+) -> None:
+    lib_dir, _, link, _, env = install_fixture(tmp_path)
+    env["VERSION"] = configured_version
+    env["TEST_LATEST_FAIL"] = "1"
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode == 0, result.stderr
+    urls = Path(env["TEST_CURL_LOG"]).read_text().splitlines()
+    assert len(urls) == 2
+    assert all("/releases/latest" not in url for url in urls)
+    assert all("/releases/download/v2.3.4/" in url for url in urls)
+    assert urls[1] == f"{urls[0]}.sha256"
+    assert (
+        subprocess.run(
+            [str(link)], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "new"
+    )
+    assert (lib_dir / "new-only").read_text() == "new payload\n"
+
+
+def test_unset_version_uses_latest_release_tag(tmp_path: Path) -> None:
+    lib_dir, _, link, _, env = install_fixture(tmp_path)
+    env.pop("VERSION")
+    env["TEST_LATEST_URL"] = (
+        "https://github.com/chauduyphanvu/audible-deals/releases/tag/v2.4.5"
+    )
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode == 0, result.stderr
+    urls = Path(env["TEST_CURL_LOG"]).read_text().splitlines()
+    assert urls[0] == ("https://github.com/chauduyphanvu/audible-deals/releases/latest")
+    assert len(urls) == 3
+    assert all("/releases/download/v2.4.5/" in url for url in urls[1:])
+    assert urls[2] == f"{urls[1]}.sha256"
+    assert (
+        subprocess.run(
+            [str(link)], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "new"
+    )
+    assert (lib_dir / "new-only").read_text() == "new payload\n"
+
+
+@pytest.mark.parametrize(
+    ("transport_failure", "latest_url"),
+    [
+        (
+            True,
+            "https://github.com/chauduyphanvu/audible-deals/releases/tag/v2.4.5",
+        ),
+        (False, ""),
+        (
+            False,
+            "https://example.com/chauduyphanvu/audible-deals/releases/tag/v2.4.5",
+        ),
+        (
+            False,
+            "https://github.com/chauduyphanvu/audible-deals/releases/download/v2.4.5",
+        ),
+        (
+            False,
+            "https://github.com/chauduyphanvu/audible-deals/releases/tag/not-a-version",
+        ),
+        (
+            False,
+            "https://github.com/chauduyphanvu/audible-deals/releases/tag/v2.4.5/notes",
+        ),
+        (
+            False,
+            "https://github.com/chauduyphanvu/audible-deals/releases/tag/v2.4.5?source=latest",
+        ),
+    ],
+    ids=[
+        "transport-error",
+        "empty-url",
+        "wrong-host",
+        "wrong-path",
+        "invalid-tag",
+        "trailing-component",
+        "query-string",
+    ],
+)
+def test_unset_version_resolution_failure_preserves_existing_install(
+    tmp_path: Path, transport_failure: bool, latest_url: str
+) -> None:
+    lib_dir, _, link, _, env = install_fixture(tmp_path)
+    env.pop("VERSION")
+    env["TEST_LATEST_URL"] = latest_url
+    if transport_failure:
+        env["TEST_LATEST_FAIL"] = "1"
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert result.stderr.strip() == (
+        "Error: Could not resolve the latest release from GitHub; "
+        "retry or set VERSION explicitly."
+    )
+    assert Path(env["TEST_CURL_LOG"]).read_text().splitlines() == [
+        "https://github.com/chauduyphanvu/audible-deals/releases/latest"
+    ]
+    assert_old_install_works(lib_dir, link)
+    assert (lib_dir / "old-only").read_text() == "old payload"
+    assert (lib_dir / INSTALL_MARKER_NAME).read_text() == INSTALL_MARKER_CONTENT
+    assert_no_temporary_files(tmp_path, lib_dir)
 
 
 def test_download_failure_preserves_install(tmp_path: Path) -> None:

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,0 +1,838 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import tarfile
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SCRIPT = ROOT / "install.sh"
+BASH = shutil.which("bash") or "/bin/bash"
+REAL_MV = shutil.which("mv") or "/bin/mv"
+REAL_LN = shutil.which("ln") or "/bin/ln"
+REAL_CP = shutil.which("cp") or "/bin/cp"
+INSTALL_MARKER_NAME = ".audible-deals-install"
+INSTALL_MARKER_CONTENT = "repository=chauduyphanvu/audible-deals"
+
+
+def write_executable(path: Path, output: str) -> None:
+    path.write_text(f"#!/bin/sh\nprintf '%s\\n' {shlex.quote(output)}\n")
+    path.chmod(0o755)
+
+
+def write_install_marker(directory: Path) -> None:
+    (directory / INSTALL_MARKER_NAME).write_text(INSTALL_MARKER_CONTENT)
+
+
+def make_archive(path: Path, files: dict[str, bytes]) -> None:
+    with tarfile.open(path, "w:gz") as archive:
+        for name, contents in files.items():
+            info = tarfile.TarInfo(f"bundle/{name}")
+            info.size = len(contents)
+            info.mode = 0o644
+            archive.addfile(info, fileobj=io.BytesIO(contents))
+
+
+def write_checksum(archive: Path, checksum: Path, digest: str | None = None) -> None:
+    value = digest or hashlib.sha256(archive.read_bytes()).hexdigest()
+    checksum.write_text(f"{value}  {archive.name}\n")
+
+
+def make_curl_shim(directory: Path) -> None:
+    curl = directory / "curl"
+    curl.write_text(
+        f"""#!/bin/bash
+set -eu
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            output="$2"
+            shift 2
+            ;;
+        -*)
+            shift
+            ;;
+        *)
+            url="$1"
+            shift
+            ;;
+    esac
+done
+if [ "${{TEST_DOWNLOAD_FAIL:-0}}" = "1" ] && [[ "$url" != *.sha256 ]]; then
+    exit 22
+fi
+if [[ "$url" = *.sha256 ]]; then
+    [ -n "${{TEST_CHECKSUM:-}}" ] || exit 22
+    exec {shlex.quote(REAL_CP)} "$TEST_CHECKSUM" "$output"
+fi
+exec {shlex.quote(REAL_CP)} "$TEST_ARCHIVE" "$output"
+"""
+    )
+    curl.chmod(0o755)
+
+
+def make_mv_shim(directory: Path) -> None:
+    mv = directory / "mv"
+    mv.write_text(
+        f"""#!/bin/bash
+set -eu
+args=("$@")
+operands=()
+for argument in "${{args[@]}}"; do
+    case "$argument" in
+        -*) ;;
+        *) operands[${{#operands[@]}}]="$argument" ;;
+    esac
+done
+count=${{#operands[@]}}
+source_path="${{operands[$((count - 2))]}}"
+destination="${{operands[$((count - 1))]}}"
+mode="${{MV_FAIL_MODE:-}}"
+if [ "$destination" = "$LIB_DIR" ]; then
+    if [[ "$source_path" = */.deals-install.*/payload ]] && \
+       {{ [ "$mode" = "promotion" ] || [ "$mode" = "promotion_restore" ]; }}; then
+        exit 71
+    fi
+    if [[ "$source_path" = */.deals-install.*/payload ]] && \
+       [ "$mode" = "promotion_post_move_failure" ]; then
+        {shlex.quote(REAL_MV)} "$@"
+        exit 74
+    fi
+    if [[ "$source_path" = */.deals-install.*/backup ]] && \
+       [ "$mode" = "promotion_restore" ]; then
+        exit 72
+    fi
+fi
+if [ "$source_path" = "$LIB_DIR" ] && \
+   [[ "$destination" = */.deals-install.*/backup ]] && \
+   [ "$mode" = "signal_after_backup" ]; then
+    {shlex.quote(REAL_MV)} "$@"
+    kill -TERM "$PPID"
+    exit 0
+fi
+if [ "$source_path" = "$LIB_DIR" ] && \
+   [[ "$destination" = */.deals-install.*/backup ]] && \
+   [ "$mode" = "backup_post_move_failure" ]; then
+    {shlex.quote(REAL_MV)} "$@"
+    exit 76
+fi
+exec {shlex.quote(REAL_MV)} "$@"
+"""
+    )
+    mv.chmod(0o755)
+
+
+def make_ln_shim(directory: Path) -> None:
+    ln = directory / "ln"
+    ln.write_text(
+        f"""#!/bin/bash
+set -eu
+target="$2"
+destination="$3"
+mode="${{LN_FAIL_MODE:-}}"
+case "$mode" in
+    failure)
+        exit 73
+        ;;
+    post_create_failure)
+        {shlex.quote(REAL_LN)} "$@"
+        exit 75
+        ;;
+    concurrent_exact_symlink)
+        {shlex.quote(REAL_LN)} -s "$target" "$destination"
+        ;;
+    concurrent_regular)
+        printf '#!/bin/sh\nprintf "%%s\\n" "concurrent command"\n' > "$destination"
+        chmod +x "$destination"
+        ;;
+    concurrent_foreign_symlink)
+        {shlex.quote(REAL_LN)} -s "$TEST_FOREIGN_COMMAND" "$destination"
+        ;;
+esac
+exec {shlex.quote(REAL_LN)} -s "$target" "$destination"
+"""
+    )
+    ln.chmod(0o755)
+
+
+def base_environment(
+    tmp_path: Path,
+    lib_dir: Path,
+    install_dir: Path,
+    archive: Path,
+    checksum: Path,
+) -> dict[str, str]:
+    home = tmp_path / "home"
+    shim_dir = tmp_path / "shims"
+    download_root = tmp_path / "downloads"
+    home.mkdir(exist_ok=True)
+    shim_dir.mkdir(exist_ok=True)
+    download_root.mkdir(exist_ok=True)
+    install_dir.mkdir(parents=True, exist_ok=True)
+    make_curl_shim(shim_dir)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "INSTALL_DIR": str(install_dir),
+            "LIB_DIR": str(lib_dir),
+            "PATH": os.pathsep.join(
+                [str(shim_dir), str(install_dir), os.environ.get("PATH", "")]
+            ),
+            "SHELL": BASH,
+            "TEST_ARCHIVE": str(archive),
+            "TEST_CHECKSUM": str(checksum),
+            "TMPDIR": str(download_root),
+            "VERSION": "1.2.3",
+        }
+    )
+    return env
+
+
+def setup_old_install(lib_dir: Path, install_dir: Path) -> Path:
+    lib_dir.mkdir(parents=True)
+    write_executable(lib_dir / "deals", "old")
+    (lib_dir / "old-only").write_text("old payload")
+    write_install_marker(lib_dir)
+    install_dir.mkdir(parents=True, exist_ok=True)
+    link = install_dir / "deals"
+    link.symlink_to(lib_dir / "deals")
+    return link
+
+
+def run_installer(
+    tmp_path: Path, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    cwd = tmp_path / "work"
+    cwd.mkdir(exist_ok=True)
+    return subprocess.run(
+        [BASH, str(INSTALL_SCRIPT)],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def run_validator(
+    candidate: str,
+    *,
+    cwd: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            BASH,
+            "-c",
+            'source "$1"; validate_lib_dir "$2"',
+            "bash",
+            str(INSTALL_SCRIPT),
+            candidate,
+        ],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def assert_old_install_works(lib_dir: Path, link: Path) -> None:
+    assert (
+        subprocess.run(
+            [str(lib_dir / "deals")], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "old"
+    )
+    assert (
+        subprocess.run(
+            [str(link)], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "old"
+    )
+
+
+def assert_no_temporary_files(tmp_path: Path, lib_dir: Path) -> None:
+    assert list(lib_dir.parent.glob(".deals-install.*")) == []
+    assert list((tmp_path / "downloads").iterdir()) == []
+
+
+def install_fixture(
+    tmp_path: Path,
+    files: dict[str, bytes] | None = None,
+) -> tuple[Path, Path, Path, Path, dict[str, str]]:
+    archive = tmp_path / "release.tar.gz"
+    checksum = tmp_path / "release.tar.gz.sha256"
+    make_archive(
+        archive,
+        files
+        or {
+            "deals": b"#!/bin/sh\nprintf '%s\\n' new\n",
+            "new-only": b"new payload\n",
+        },
+    )
+    write_checksum(archive, checksum)
+    lib_dir = tmp_path / "library" / "custom-location"
+    install_dir = tmp_path / "commands" / "bin"
+    link = setup_old_install(lib_dir, install_dir)
+    env = base_environment(tmp_path, lib_dir, install_dir, archive, checksum)
+    return lib_dir, install_dir, link, archive, env
+
+
+def test_rejects_unsafe_lib_dirs(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    safe_cwd = tmp_path / "validator-work"
+    safe_cwd.mkdir()
+    occupied = tmp_path / "nested" / "occupied"
+    occupied.mkdir(parents=True)
+    (occupied / "unrelated-file").write_text("not an install")
+    home_link = tmp_path / "home-link"
+    home_link.symlink_to(home, target_is_directory=True)
+
+    shim_dir = tmp_path / "validator-shims"
+    shim_dir.mkdir()
+    curl = shim_dir / "curl"
+    curl.write_text("#!/bin/sh\nexit 22\n")
+    curl.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "INSTALL_DIR": str(tmp_path / "safe-source" / "bin"),
+            "LIB_DIR": str(tmp_path / "safe-source" / "lib"),
+            "PATH": os.pathsep.join([str(shim_dir), os.environ.get("PATH", "")]),
+            "VERSION": "1.2.3",
+        }
+    )
+
+    candidates = [
+        "",
+        "/",
+        str(home),
+        str(tmp_path),
+        "/audible-deals-unsafe-validator-target",
+        str(home_link),
+        str(occupied),
+    ]
+    for candidate in candidates:
+        result = run_validator(candidate, cwd=safe_cwd, env=env)
+        assert result.returncode != 0, (candidate, result.stdout, result.stderr)
+
+    assert not (tmp_path / "safe-source").exists()
+
+
+def test_resolves_relative_lib_dirs(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    cwd = home / "projects" / "current"
+    cwd.mkdir(parents=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "INSTALL_DIR": str(home / "safe" / "bin"),
+            "LIB_DIR": str(home / "safe" / "lib"),
+        }
+    )
+
+    current = run_validator("./custom", cwd=cwd, env=env)
+    assert current.returncode == 0, current.stderr
+    assert current.stdout.strip() == str(cwd / "custom")
+
+    sibling = run_validator("../shared/custom", cwd=cwd, env=env)
+    assert sibling.returncode == 0, sibling.stderr
+    assert sibling.stdout.strip() == str(home / "projects" / "shared" / "custom")
+
+    forbidden = run_validator("../..", cwd=cwd, env=env)
+    assert forbidden.returncode != 0
+
+
+def test_existing_install_marker_allows_custom_path(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    custom = tmp_path / "arbitrary" / "bundle-location"
+    custom.mkdir(parents=True)
+    write_executable(custom / "deals", "old")
+    (custom / "other-file").write_text("part of the bundle")
+    write_install_marker(custom)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "INSTALL_DIR": str(tmp_path / "safe" / "bin"),
+            "LIB_DIR": str(tmp_path / "safe" / "lib"),
+        }
+    )
+
+    result = run_validator(str(custom), cwd=cwd, env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(custom)
+
+
+def test_custom_binary_without_marker_is_rejected_and_preserved(tmp_path: Path) -> None:
+    archive = tmp_path / "release.tar.gz"
+    checksum = tmp_path / "release.tar.gz.sha256"
+    make_archive(archive, {"deals": b"#!/bin/sh\nexit 0\n"})
+    write_checksum(archive, checksum)
+    lib_dir = tmp_path / "project" / "broad-directory"
+    install_dir = tmp_path / "commands" / "bin"
+    lib_dir.mkdir(parents=True)
+    write_executable(lib_dir / "deals", "unrelated")
+    sentinel = lib_dir / "project-data"
+    sentinel.write_text("preserve me")
+    env = base_environment(tmp_path, lib_dir, install_dir, archive, checksum)
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "not a dedicated audible-deals installation" in result.stderr
+    assert sentinel.read_text() == "preserve me"
+    assert (
+        subprocess.run(
+            [str(lib_dir / "deals")], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "unrelated"
+    )
+    assert list((tmp_path / "downloads").iterdir()) == []
+
+
+def test_canonical_default_legacy_install_is_accepted(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    default = home / ".local" / "lib" / "deals"
+    cwd = tmp_path / "work"
+    default.mkdir(parents=True)
+    cwd.mkdir()
+    write_executable(default / "deals", "legacy")
+    (default / "legacy-file").write_text("legacy payload")
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "INSTALL_DIR": str(home / ".local" / "bin"),
+            "LIB_DIR": str(default),
+        }
+    )
+
+    result = run_validator(str(default), cwd=cwd, env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(default)
+
+
+@pytest.mark.parametrize("placement", ["trailing", "embedded"])
+def test_newline_lib_dir_is_rejected_without_touching_sentinel(
+    tmp_path: Path, placement: str
+) -> None:
+    archive = tmp_path / "release.tar.gz"
+    checksum = tmp_path / "release.tar.gz.sha256"
+    make_archive(archive, {"deals": b"#!/bin/sh\nexit 0\n"})
+    write_checksum(archive, checksum)
+    install_dir = tmp_path / "commands" / "bin"
+    if placement == "trailing":
+        protected_lib = tmp_path / "library" / "protected"
+        configured_lib = f"{protected_lib}\n"
+    else:
+        protected_lib = tmp_path / "library" / "protected\nsegment"
+        configured_lib = str(protected_lib)
+    link = setup_old_install(protected_lib, install_dir)
+    env = base_environment(tmp_path, protected_lib, install_dir, archive, checksum)
+    env["LIB_DIR"] = configured_lib
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "LIB_DIR must not contain newline" in result.stderr
+    assert_old_install_works(protected_lib, link)
+    assert (protected_lib / "old-only").read_text() == "old payload"
+    assert list((tmp_path / "downloads").iterdir()) == []
+
+
+@pytest.mark.parametrize("placement", ["trailing", "embedded"])
+def test_newline_install_dir_is_rejected_without_touching_sentinel(
+    tmp_path: Path, placement: str
+) -> None:
+    archive = tmp_path / "release.tar.gz"
+    checksum = tmp_path / "release.tar.gz.sha256"
+    make_archive(archive, {"deals": b"#!/bin/sh\nexit 0\n"})
+    write_checksum(archive, checksum)
+    lib_dir = tmp_path / "library" / "custom-location"
+    if placement == "trailing":
+        protected_install = tmp_path / "commands" / "protected"
+        configured_install = f"{protected_install}\n"
+    else:
+        protected_install = tmp_path / "commands" / "protected\nsegment"
+        configured_install = str(protected_install)
+    link = setup_old_install(lib_dir, protected_install)
+    env = base_environment(tmp_path, lib_dir, protected_install, archive, checksum)
+    env["INSTALL_DIR"] = configured_install
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "INSTALL_DIR must not contain newline" in result.stderr
+    assert_old_install_works(lib_dir, link)
+    assert (lib_dir / "old-only").read_text() == "old payload"
+    assert list((tmp_path / "downloads").iterdir()) == []
+
+
+def test_rejects_reverse_install_path_overlap(tmp_path: Path) -> None:
+    archive = tmp_path / "release.tar.gz"
+    checksum = tmp_path / "release.tar.gz.sha256"
+    make_archive(archive, {"deals": b"#!/bin/sh\nexit 0\n"})
+    write_checksum(archive, checksum)
+    install_dir = tmp_path / "commands" / "bin"
+    lib_dir = install_dir / "deals" / "payload"
+    env = base_environment(tmp_path, lib_dir, install_dir, archive, checksum)
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "must not overlap" in result.stderr
+    assert not (install_dir / "deals").exists()
+    assert list((tmp_path / "downloads").iterdir()) == []
+
+
+def test_download_failure_preserves_install(tmp_path: Path) -> None:
+    lib_dir, install_dir, link, _, env = install_fixture(tmp_path)
+    env["TEST_DOWNLOAD_FAIL"] = "1"
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "Download failed" in result.stderr
+    assert_old_install_works(lib_dir, link)
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_checksum_mismatch_preserves_install(tmp_path: Path) -> None:
+    lib_dir, install_dir, link, _, env = install_fixture(tmp_path)
+    Path(env["TEST_CHECKSUM"]).write_text(f"{'0' * 64}  release.tar.gz\n")
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "Checksum mismatch" in result.stderr
+    assert_old_install_works(lib_dir, link)
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_corrupt_archive_preserves_install(tmp_path: Path) -> None:
+    lib_dir, install_dir, link, archive, env = install_fixture(tmp_path)
+    archive.write_bytes(b"not a tar archive")
+    write_checksum(archive, Path(env["TEST_CHECKSUM"]))
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "Could not extract" in result.stderr
+    assert_old_install_works(lib_dir, link)
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_missing_binary_preserves_install(tmp_path: Path) -> None:
+    lib_dir, install_dir, link, _, env = install_fixture(
+        tmp_path, {"not-deals": b"wrong file\n"}
+    )
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "does not contain the expected deals binary" in result.stderr
+    assert_old_install_works(lib_dir, link)
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_invalid_executable_preserves_install(tmp_path: Path) -> None:
+    lib_dir, install_dir, link, _, env = install_fixture(
+        tmp_path, {"deals": b"\x00corrupt executable bytes\n"}
+    )
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "failed its staged --version check" in result.stderr
+    assert_old_install_works(lib_dir, link)
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_successful_upgrade_is_clean(tmp_path: Path) -> None:
+    lib_dir, install_dir, link, _, env = install_fixture(tmp_path)
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        subprocess.run(
+            [str(link)], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "new"
+    )
+    assert link.is_symlink()
+    assert os.readlink(link) == str(lib_dir / "deals")
+    assert not (lib_dir / "old-only").exists()
+    assert (lib_dir / "new-only").read_text() == "new payload\n"
+    assert (lib_dir / INSTALL_MARKER_NAME).read_text() == INSTALL_MARKER_CONTENT
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_regular_command_file_is_rejected_and_preserved(tmp_path: Path) -> None:
+    lib_dir, install_dir, link, _, env = install_fixture(tmp_path)
+    link.unlink()
+    write_executable(link, "user command")
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "unmanaged file already exists" in result.stderr
+    assert (
+        subprocess.run(
+            [str(link)], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "user command"
+    )
+    assert (lib_dir / "old-only").read_text() == "old payload"
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_foreign_command_symlink_is_rejected_and_preserved(tmp_path: Path) -> None:
+    lib_dir, install_dir, link, _, env = install_fixture(tmp_path)
+    foreign = tmp_path / "foreign" / "deals"
+    foreign.parent.mkdir()
+    write_executable(foreign, "foreign command")
+    link.unlink()
+    link.symlink_to(foreign)
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "foreign symlink already exists" in result.stderr
+    assert os.readlink(link) == str(foreign)
+    assert (
+        subprocess.run(
+            [str(link)], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "foreign command"
+    )
+    assert (lib_dir / "old-only").read_text() == "old payload"
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+FINAL_VERIFICATION_FAILURE = b"""#!/bin/sh
+case "$0" in
+    */.deals-install.*/payload/deals) exit 0 ;;
+    *) exit 42 ;;
+esac
+"""
+
+
+def test_final_link_verification_failure_restores_existing_install(
+    tmp_path: Path,
+) -> None:
+    lib_dir, install_dir, link, _, env = install_fixture(
+        tmp_path, {"deals": FINAL_VERIFICATION_FAILURE}
+    )
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "failed its final --version check" in result.stderr
+    assert_old_install_works(lib_dir, link)
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_final_link_verification_failure_removes_fresh_link(
+    tmp_path: Path,
+) -> None:
+    lib_dir, install_dir, link, _, env = install_fixture(
+        tmp_path, {"deals": FINAL_VERIFICATION_FAILURE}
+    )
+    link.unlink()
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert "failed its final --version check" in result.stderr
+    assert not link.exists()
+    assert not link.is_symlink()
+    assert (
+        subprocess.run(
+            [str(lib_dir / "deals")], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "old"
+    )
+    assert (lib_dir / "old-only").read_text() == "old payload"
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def assert_transaction_swap_failure_rolls_back(tmp_path: Path, mode: str) -> None:
+    lib_dir, install_dir, link, _, env = install_fixture(tmp_path)
+    make_mv_shim(tmp_path / "shims")
+    env["MV_FAIL_MODE"] = mode
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert_old_install_works(lib_dir, link)
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_failed_library_swap_rolls_back(tmp_path: Path) -> None:
+    assert_transaction_swap_failure_rolls_back(tmp_path, "promotion")
+
+
+def test_backup_post_move_failure_rolls_back(tmp_path: Path) -> None:
+    assert_transaction_swap_failure_rolls_back(tmp_path, "backup_post_move_failure")
+
+
+def test_promotion_post_move_failure_rolls_back(tmp_path: Path) -> None:
+    assert_transaction_swap_failure_rolls_back(tmp_path, "promotion_post_move_failure")
+
+
+def test_direct_link_creation_failure_rolls_back_library(tmp_path: Path) -> None:
+    lib_dir, _, link, _, env = install_fixture(tmp_path)
+    link.unlink()
+    make_ln_shim(tmp_path / "shims")
+    env["LN_FAIL_MODE"] = "failure"
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert not link.exists()
+    assert not link.is_symlink()
+    assert (
+        subprocess.run(
+            [str(lib_dir / "deals")], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "old"
+    )
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_link_post_create_failure_preserves_ambiguous_link_and_rolls_back(
+    tmp_path: Path,
+) -> None:
+    lib_dir, _, link, _, env = install_fixture(tmp_path)
+    link.unlink()
+    make_ln_shim(tmp_path / "shims")
+    env["LN_FAIL_MODE"] = "post_create_failure"
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert link.is_symlink()
+    assert os.readlink(link) == str(lib_dir / "deals")
+    assert (
+        subprocess.run(
+            [str(link)], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "old"
+    )
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_concurrent_exact_command_link_is_preserved(tmp_path: Path) -> None:
+    lib_dir, _, link, _, env = install_fixture(tmp_path)
+    link.unlink()
+    make_ln_shim(tmp_path / "shims")
+    env["LN_FAIL_MODE"] = "concurrent_exact_symlink"
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert link.is_symlink()
+    assert os.readlink(link) == str(lib_dir / "deals")
+    assert (
+        subprocess.run(
+            [str(link)], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "old"
+    )
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+@pytest.mark.parametrize("path_kind", ["regular", "foreign_symlink"])
+def test_concurrent_command_path_creation_is_not_clobbered(
+    tmp_path: Path, path_kind: str
+) -> None:
+    lib_dir, _, link, _, env = install_fixture(tmp_path)
+    link.unlink()
+    make_ln_shim(tmp_path / "shims")
+    env["LN_FAIL_MODE"] = f"concurrent_{path_kind}"
+
+    if path_kind == "foreign_symlink":
+        foreign = tmp_path / "foreign" / "deals"
+        foreign.parent.mkdir()
+        write_executable(foreign, "concurrent command")
+        env["TEST_FOREIGN_COMMAND"] = str(foreign)
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert (
+        subprocess.run(
+            [str(link)], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "concurrent command"
+    )
+    if path_kind == "foreign_symlink":
+        assert os.readlink(link) == str(foreign)
+    else:
+        assert not link.is_symlink()
+    assert (
+        subprocess.run(
+            [str(lib_dir / "deals")], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "old"
+    )
+    assert (lib_dir / "old-only").read_text() == "old payload"
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_interrupt_after_backup_move_rolls_back(tmp_path: Path) -> None:
+    lib_dir, _, link, _, env = install_fixture(tmp_path)
+    make_mv_shim(tmp_path / "shims")
+    env["MV_FAIL_MODE"] = "signal_after_backup"
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    assert_old_install_works(lib_dir, link)
+    assert_no_temporary_files(tmp_path, lib_dir)
+
+
+def test_failed_restore_retains_backup(tmp_path: Path) -> None:
+    lib_dir, _, link, _, env = install_fixture(tmp_path)
+    make_mv_shim(tmp_path / "shims")
+    env["MV_FAIL_MODE"] = "promotion_restore"
+
+    result = run_installer(tmp_path, env)
+
+    assert result.returncode != 0
+    match = re.search(r"backup was preserved at:\n  (.+/backup)\n", result.stderr)
+    assert match, result.stderr
+    backup = Path(match.group(1))
+    assert backup.is_dir()
+    assert (
+        subprocess.run(
+            [str(backup / "deals")], text=True, capture_output=True, check=True
+        ).stdout.strip()
+        == "old"
+    )
+    assert not lib_dir.exists()
+    assert link.is_symlink()
+    assert backup.parent.is_dir()

--- a/tests/test_result_sessions.py
+++ b/tests/test_result_sessions.py
@@ -39,6 +39,7 @@ from audible_deals.results_cache import (
     clear_dismissed_asins,
     load_dismissed_asins,
     load_result_session,
+    load_seen_asins,
     save_dismissed_asins,
     save_result_session,
 )
@@ -532,7 +533,6 @@ def test_publication_snapshots_histories_before_recording_prices(
         )
     )
 
-    assert outcome.session is not None
     assert outcome.session.constraints["history_percentiles"] == {product.asin: 100}
     assert outcome.session.constraints["price_drop_pcts"] == {product.asin: -100.0}
     persisted = load_result_session()
@@ -559,16 +559,16 @@ def test_safe_history_wrapper_forwards_observation_date(monkeypatch):
     }
 
 
-def test_publication_records_and_marks_only_visible_numeric_products(tmp_config):
+def test_publication_scopes_surface_effects_to_visible_products(tmp_config):
     visible = make_product(asin="B00VISIBLE", price=4, series_name="")
     hidden = make_product(asin="B00HIDDEN1", price=5, series_name="")
     unavailable = make_product(asin="B00UNAVAIL", price=None, series_name="")
 
     outcome = publish_discovery(
         ResultPublicationRequest(
-            result=DiscoveryResult((visible, hidden, unavailable)),
+            result=DiscoveryResult((visible, unavailable, hidden)),
             title="Surface",
-            limit=1,
+            limit=2,
             output=None,
             json_flag=False,
             quiet=True,
@@ -578,15 +578,26 @@ def test_publication_records_and_marks_only_visible_numeric_products(tmp_config)
             session_spec=ResultSessionSpec(
                 producer="find",
                 locale="us",
-                recipe=result_recipe(limit=1),
+                recipe=result_recipe(limit=2),
                 source={"command": "deals find"},
                 constraints={"drop_zero_length": True},
             ),
         )
     )
 
-    assert outcome.session is not None
+    assert [product.asin for product in outcome.products] == [
+        visible.asin,
+        unavailable.asin,
+    ]
+    assert outcome.session.visible_asins == [visible.asin, unavailable.asin]
     assert {item["asin"] for item in outcome.session.candidates} == {
+        visible.asin,
+        hidden.asin,
+        unavailable.asin,
+    }
+    persisted = load_result_session()
+    assert persisted.visible_asins == [visible.asin, unavailable.asin]
+    assert {item["asin"] for item in persisted.candidates} == {
         visible.asin,
         hidden.asin,
         unavailable.asin,
@@ -597,6 +608,53 @@ def test_publication_records_and_marks_only_visible_numeric_products(tmp_config)
     assert load_refresh_eligibility() == {
         "us": {visible.asin: datetime.date.today().isoformat()}
     }
+    assert load_seen_asins() == {visible.asin, unavailable.asin}
+
+
+def test_publication_continues_surface_effects_when_session_save_fails(
+    tmp_config, monkeypatch, caplog
+):
+    product = make_product(asin="B00SAVEFAIL", price=4, series_name="")
+    written = []
+
+    def fail_save(_session):
+        raise OSError("cache unavailable")
+
+    monkeypatch.setattr(
+        "audible_deals.result_publication.save_result_session", fail_save
+    )
+
+    outcome = publish_discovery(
+        ResultPublicationRequest(
+            result=DiscoveryResult((product,)),
+            title="Save failure",
+            limit=0,
+            output=None,
+            json_flag=True,
+            quiet=False,
+            max_price=None,
+            currency="$",
+            candidates=(product,),
+            session_spec=ResultSessionSpec(
+                producer="find",
+                locale="us",
+                recipe=result_recipe(limit=0),
+                source={"command": "deals find"},
+                constraints={"drop_zero_length": True},
+            ),
+            json_writer=written.append,
+        )
+    )
+
+    assert json.loads(written[0])[0]["asin"] == product.asin
+    assert outcome.session.visible_asins == [product.asin]
+    assert not constants.LAST_RESULTS_FILE.exists()
+    assert load_price_history(product.asin) != []
+    assert load_refresh_eligibility() == {
+        "us": {product.asin: datetime.date.today().isoformat()}
+    }
+    assert load_seen_asins() == {product.asin}
+    assert "Could not save last result session" in caplog.text
 
 
 @pytest.mark.parametrize("failure", ["json", "export"])

--- a/tests/test_taste.py
+++ b/tests/test_taste.py
@@ -10,7 +10,6 @@ from click.testing import CliRunner
 
 import audible_deals.constants as constants_mod
 import audible_deals.wishlist as wishlist_mod
-from audible_deals.client import SeriesProductsBatch
 from audible_deals.cli import cli
 from audible_deals.results_cache import (
     clear_dismissed_asins,
@@ -24,7 +23,7 @@ from audible_deals.taste import (
     rank_by_fit,
     save_profile,
 )
-from tests.conftest import make_product
+from tests.conftest import make_product, make_series_products_batch
 
 
 def _lib_book(asin, author, narrator="Narrator One", series="", pos="", **kw):
@@ -379,7 +378,9 @@ def _wire_scans(mock_client):
         series_name="",
         series_position="",
     )
-    mock_client.get_series_products.return_value = [series_book, owned_book]
+    mock_client.get_series_products_many.return_value = make_series_products_batch(
+        {"SERIESA01": [series_book, owned_book]}
+    )
 
     def fake_search_pages(**kwargs):
         if kwargs.get("category_id"):
@@ -464,7 +465,9 @@ class TestForMeCommand:
             series_asin="SERIESA01",
             series_position="4",
         )
-        mock_client.get_series_products.return_value = [alternate, gap]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SERIESA01": [alternate, gap]}
+        )
         mock_client.search_pages.side_effect = [
             iter([([alternate], 1, 1)]),
             iter([([alternate], 1, 1)]),
@@ -492,11 +495,9 @@ class TestForMeCommand:
         )
         expensive = dataclasses.replace(unavailable, asin="EXPENSIVE", price=8.0)
         cheapest = dataclasses.replace(unavailable, asin="CHEAPEST", price=3.0)
-        mock_client.get_series_products.return_value = [
-            unavailable,
-            expensive,
-            cheapest,
-        ]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SERIESA01": [unavailable, expensive, cheapest]}
+        )
         mock_client.search_pages.return_value = iter([])
 
         result = CliRunner().invoke(cli, ["for-me", "--json"])
@@ -526,7 +527,9 @@ class TestForMeCommand:
         next_book = dataclasses.replace(
             later, asin="NEXT", title="Actual Next", series_position="4"
         )
-        mock_client.get_series_products.return_value = [later, ambiguous, next_book]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SERIESA01": [later, ambiguous, next_book]}
+        )
         mock_client.search_pages.return_value = iter([])
 
         result = CliRunner().invoke(cli, ["for-me", "--json"])
@@ -569,11 +572,9 @@ class TestForMeCommand:
             price=2.0,
             length_minutes=0,
         )
-        mock_client.get_series_products.return_value = [
-            unavailable,
-            placeholder,
-            zero_runtime,
-        ]
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SERIESA01": [unavailable, placeholder, zero_runtime]}
+        )
         mock_client.search_pages.return_value = iter([])
 
         result = CliRunner().invoke(cli, ["for-me", "--json"])
@@ -661,7 +662,7 @@ class TestForMeCommand:
         assert result.exit_code == 0, result.output
         assert "Bobiverse" in result.output
         assert "Fav Author" in result.output
-        mock_client.get_series_products.assert_not_called()
+        mock_client.get_series_products_many.assert_not_called()
         mock_client.search_pages.assert_not_called()
 
     def test_builds_profile_from_library_when_no_cache(self, mock_client, tmp_config):
@@ -736,10 +737,8 @@ class TestForMeCommand:
             series_position="4",
             price=4.99,
         )
-        mock_client.get_series_products_many.side_effect = None
-        mock_client.get_series_products_many.return_value = SeriesProductsBatch(
-            products={"SERIESA01": (gap,)},
-            failures={},
+        mock_client.get_series_products_many.return_value = make_series_products_batch(
+            {"SERIESA01": [gap]},
             missing_asins={"SERIESA01": ("B00MISSING",)},
         )
 

--- a/tests/test_taste.py
+++ b/tests/test_taste.py
@@ -745,8 +745,11 @@ class TestForMeCommand:
         result = CliRunner().invoke(cli, ["for-me", "--json"])
 
         assert result.exit_code == 0, result.output
-        assert "1/1 series scanned; 1 incomplete" in result.stderr
-        assert "Bobiverse: 1 product(s) unavailable" in result.stderr
+        assert result.stderr.endswith(
+            "Partial results: 1/1 series scanned; 1 incomplete.\n"
+            "  Bobiverse: 1 product(s) unavailable\n"
+        )
+        assert "Partial results:" not in result.stdout
         assert any(item["asin"] == gap.asin for item in json.loads(result.stdout))
 
     def test_narrow_terminal_folds_match_into_title(self, mock_client, tmp_config):

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -21,6 +21,7 @@ from audible_deals.scheduler import (
     generate_launchd_plist,
     generate_systemd_service,
     generate_systemd_timer,
+    generate_windows_task_command,
     track_command,
     uninstall,
 )
@@ -856,6 +857,93 @@ class TestBugfixSchedulerCronLineHonorsInterval:
             )
         with pytest.raises(SchedulerError, match="seconds"):
             generate_cron_line(["/usr/bin/deals", "track", "run"], 630, Path("/l"))
+
+
+class TestWindowsTaskCommand:
+    def test_exact_ordinary_payload(self):
+        payload = generate_windows_task_command(
+            [r"C:\Tools\deals.exe", "track", "run"],
+            Path(r"C:\Logs\track.log"),
+        )
+
+        assert payload == (
+            'cmd.exe /D /S /V:OFF /C ""C:\\Tools\\deals.exe" "track" "run" '
+            '>> "C:\\Logs\\track.log" 2>&1"'
+        )
+
+    def test_quotes_supported_metacharacters(self):
+        payload = generate_windows_task_command(
+            [
+                r"C:\Program Files\Deals & Tools\deals^(prod!).exe",
+                "track & review",
+                "run^(!)",
+            ],
+            Path(r"C:\Logs & Reports\track^(!).log"),
+        )
+
+        assert payload == (
+            'cmd.exe /D /S /V:OFF /C ""C:\\Program Files\\Deals & Tools\\'
+            'deals^(prod!).exe" "track & review" "run^(!)" >> '
+            '"C:\\Logs & Reports\\track^(!).log" 2>&1"'
+        )
+
+    def test_doubles_trailing_backslashes_before_the_closing_quote(self):
+        payload = generate_windows_task_command(
+            ["deals", "ends-with-backslash\\", "sentinel"],
+            Path(r"C:\Logs\track.log"),
+        )
+
+        assert '"ends-with-backslash\\\\" "sentinel"' in payload
+
+    @pytest.mark.parametrize(
+        "unsafe", ['"', "\r", "\n", "\0", "<", ">", "|", "%", "%%", "%TEMP%"]
+    )
+    @pytest.mark.parametrize("target", ["command", "log"])
+    def test_rejects_unsafe_or_expanding_values(self, unsafe, target):
+        cmd = ["deals", f"track{unsafe}", "run"] if target == "command" else ["deals"]
+        log_path = (
+            Path(r"C:\Logs\track.log")
+            if target == "command"
+            else Path(f"C:\\Logs\\track{unsafe}.log")
+        )
+
+        with pytest.raises(SchedulerError, match="unsafe characters"):
+            generate_windows_task_command(cmd, log_path)
+
+    def test_rejects_empty_command(self):
+        with pytest.raises(SchedulerError, match="cannot be empty"):
+            generate_windows_task_command([], Path(r"C:\Logs\track.log"))
+
+    def test_install_passes_exact_schtasks_argv(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            scheduler_mod,
+            "track_command",
+            lambda: [r"C:\Program Files\Audible Deals\deals.exe", "track", "run"],
+        )
+        monkeypatch.setattr(scheduler_mod, "_run", lambda cmd: calls.append(cmd))
+
+        scheduler_mod._schtasks_install(
+            30 * 60, Path(r"C:\Users\Me\Audible Deals\track.log")
+        )
+
+        assert calls == [
+            [
+                "schtasks",
+                "/Create",
+                "/F",
+                "/TN",
+                "AudibleDealsTrack",
+                "/TR",
+                'cmd.exe /D /S /V:OFF /C ""C:\\Program Files\\Audible Deals\\'
+                'deals.exe" "track" "run" >> "C:\\Users\\Me\\Audible Deals\\'
+                'track.log" 2>&1"',
+                "/SC",
+                "MINUTE",
+                "/MO",
+                "30",
+            ]
+        ]
 
 
 class TestBugfixSchedulerWindowsScheduleHonorsInterval:

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15,<0.16" },
 ]
 provides-extras = ["dev", "docs"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "audible-deals"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "audible" },


### PR DESCRIPTION
## Summary

- make the installer transactional and path-safe, and remove its stale version fallback
- preserve Windows scheduled tracking logs with command-safe quoting
- remove unsupported obsolete APIs and migrate tests to the batch series API
- require result publication sessions and consolidate partial-series reporting

## Validation

- 1,725 tests passed
- Ruff lint and formatting passed
- ShellCheck and Bash syntax validation passed
- MkDocs strict build passed
- live macOS arm64 installation of v0.11.0 passed with the hardened installer

## Remaining platform check

- A real Windows scheduled task was not exercised because no Windows runner or host was available; payload construction and quoting are covered by tests.